### PR TITLE
Fix failing builds because of permission denied

### DIFF
--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -27,7 +27,9 @@ RUN chown -R 1000:1000 /opt/conda/pkgs && \
     mkdir -p /var/lib/conda-store && \
     chown 1000:1000 /var/lib/conda-store && \
     mkdir -p /opt/conda-store/envs && \
-    chown 1000:1000 /opt/conda-store/envs
+    chown 1000:1000 /opt/conda-store/envs && \
+    mkdir /.cache && \
+    chown 1000:1000 /.cache
 
 USER 1000:1000
 


### PR DESCRIPTION
With the latest version of conda-store, I am unable to build an environment, with the following error :

```
CondaError: Error encountered while attempting to create cache directory.
  Directory: /.cache/conda/notices
  Exception: [Errno 13] Permission denied: '/.cache'
```
This PR fixes it by creating the `/.cache` dir in the docker container and giving it the correct rights.
This occured on my Mac with Docker version 20.10.17, build 100c701 as well on a dev of conda-store-ui with a M1 Mac (no other details but exact same error)


Full log : 

```
Transaction

  Prefix: /var/lib/conda-store/filesystem/459e94e808d08b4f8dac9fe8d327ebeef05d8507fa559ae89050ff383dc0a6c3-20220908-064942-639462-2-python-flask-env

  Updating specs:

   - pip
   - python==3.9
   - flask
   - ipykernel


  Package                            Version  Build               Channel                    Size
â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
  Install:
â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€

  + _libgcc_mutex                        0.1  conda_forge         conda-forge/linux-64     Cached
  + _openmp_mutex                        4.5  2_gnu               conda-forge/linux-64     Cached
  + asttokens                          2.0.8  pyhd8ed1ab_0        conda-forge/noarch         25kB
  + backcall                           0.2.0  pyh9f0ad1d_0        conda-forge/noarch         14kB
  + backports                            1.0  py_2                conda-forge/noarch       Cached
  + backports.functools_lru_cache      1.6.4  pyhd8ed1ab_0        conda-forge/noarch       Cached
  + ca-certificates                2022.6.15  ha878542_0          conda-forge/linux-64     Cached
  + click                              8.1.3  py39hf3d152e_0      conda-forge/linux-64      149kB
  + debugpy                            1.6.3  py39h5a03fae_0      conda-forge/linux-64        2MB
  + decorator                          5.1.1  pyhd8ed1ab_0        conda-forge/noarch         12kB
  + entrypoints                          0.4  pyhd8ed1ab_0        conda-forge/noarch          9kB
  + executing                          1.0.0  pyhd8ed1ab_0        conda-forge/noarch         19kB
  + flask                              2.2.2  pyhd8ed1ab_0        conda-forge/noarch         76kB
  + importlib-metadata                4.11.4  py39hf3d152e_0      conda-forge/linux-64       34kB
  + ipykernel                         6.15.2  pyh210e3f2_0        conda-forge/noarch         98kB
  + ipython                            8.5.0  pyh41d4057_1        conda-forge/noarch        565kB
  + itsdangerous                       2.1.2  pyhd8ed1ab_0        conda-forge/noarch       Cached
  + jedi                              0.18.1  pyhd8ed1ab_2        conda-forge/noarch        818kB
  + jinja2                             3.1.2  pyhd8ed1ab_1        conda-forge/noarch       Cached
  + jupyter_client                     7.3.5  pyhd8ed1ab_0        conda-forge/noarch         93kB
  + jupyter_core                      4.11.1  py39hf3d152e_0      conda-forge/linux-64       83kB
  + ld_impl_linux-64                  2.36.1  hea4e1c9_2          conda-forge/linux-64     Cached
  + libffi                               3.3  h58526e2_2          conda-forge/linux-64       53kB
  + libgcc-ng                         12.1.0  h8d9b700_16         conda-forge/linux-64     Cached
  + libgomp                           12.1.0  h8d9b700_16         conda-forge/linux-64     Cached
  + libsodium                         1.0.18  h36c2ea0_1          conda-forge/linux-64      375kB
  + libsqlite                         3.39.3  h753d276_0          conda-forge/linux-64     Cached
  + libstdcxx-ng                      12.1.0  ha89aaad_16         conda-forge/linux-64     Cached
  + libzlib                           1.2.12  h166bdaf_2          conda-forge/linux-64     Cached
  + markupsafe                         2.1.1  py39hb9d737c_1      conda-forge/linux-64       23kB
  + matplotlib-inline                  0.1.6  pyhd8ed1ab_0        conda-forge/noarch         12kB
  + ncurses                              6.3  h27087fc_1          conda-forge/linux-64     Cached
  + nest-asyncio                       1.5.5  pyhd8ed1ab_0        conda-forge/noarch          9kB
  + openssl                           1.1.1q  h166bdaf_0          conda-forge/linux-64     Cached
  + packaging                           21.3  pyhd8ed1ab_0        conda-forge/noarch         36kB
  + parso                              0.8.3  pyhd8ed1ab_0        conda-forge/noarch         71kB
  + pexpect                            4.8.0  pyh9f0ad1d_2        conda-forge/noarch       Cached
  + pickleshare                        0.7.5  py_1003             conda-forge/noarch          9kB
  + pip                               22.2.2  pyhd8ed1ab_0        conda-forge/noarch       Cached
  + prompt-toolkit                    3.0.31  pyha770c72_0        conda-forge/noarch       Cached
  + psutil                             5.9.2  py39hb9d737c_0      conda-forge/linux-64      354kB
  + ptyprocess                         0.7.0  pyhd3deb0d_0        conda-forge/noarch       Cached
  + pure_eval                          0.2.2  pyhd8ed1ab_0        conda-forge/noarch         15kB
  + pygments                          2.13.0  pyhd8ed1ab_0        conda-forge/noarch        840kB
  + pyparsing                          3.0.9  pyhd8ed1ab_0        conda-forge/noarch       Cached
  + python                             3.9.0  hffdb5ce_5_cpython  conda-forge/linux-64       30MB
  + python-dateutil                    2.8.2  pyhd8ed1ab_0        conda-forge/noarch       Cached
  + python_abi                           3.9  2_cp39              conda-forge/linux-64        4kB
  + pyzmq                             23.2.1  py39headdf64_0      conda-forge/linux-64      489kB
  + readline                           8.1.2  h0f457ee_0          conda-forge/linux-64     Cached
  + setuptools                        65.3.0  pyhd8ed1ab_1        conda-forge/noarch       Cached
  + six                               1.16.0  pyh6c4a22f_0        conda-forge/noarch       Cached
  + sqlite                            3.39.3  h4ff8645_0          conda-forge/linux-64      808kB
  + stack_data                         0.5.0  pyhd8ed1ab_0        conda-forge/noarch         24kB
  + tk                                8.6.12  h27826a3_0          conda-forge/linux-64     Cached
  + tornado                              6.2  py39hb9d737c_0      conda-forge/linux-64      673kB
  + traitlets                          5.3.0  pyhd8ed1ab_0        conda-forge/noarch       Cached
  + tzdata                             2022c  h191b570_0          conda-forge/noarch       Cached
  + wcwidth                            0.2.5  pyh9f0ad1d_2        conda-forge/noarch       Cached
  + werkzeug                           2.2.2  pyhd8ed1ab_0        conda-forge/noarch        255kB
  + wheel                             0.37.1  pyhd8ed1ab_0        conda-forge/noarch       Cached
  + xz                                 5.2.6  h166bdaf_0          conda-forge/linux-64     Cached
  + zeromq                             4.3.4  h9c3ff4c_1          conda-forge/linux-64      360kB
  + zipp                               3.8.1  pyhd8ed1ab_0        conda-forge/noarch       Cached
  + zlib                              1.2.12  h166bdaf_2          conda-forge/linux-64       93kB

  Summary:

  Install: 65 packages

  Total download: 39MB

â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€


EnvironmentSectionNotValid: The following section on '/tmp/tmp7jeo1z6c/environment.yaml' is invalid and will be ignored:
 - description

Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.


Looking for: ['pip', 'python==3.9', 'flask', 'ipykernel']


Preparing transaction: ...working... done
Verifying transaction: ...working... WARNING conda.core.path_actions:verify(958): Unable to create environments file. Path not writable.
  environment location: /.conda/environments.txt

done
Executing transaction: ...working... WARNING conda.core.envs_manager:register_env(51): Unable to register environment. Path not writable or missing.
  environment location: /var/lib/conda-store/filesystem/459e94e808d08b4f8dac9fe8d327ebeef05d8507fa559ae89050ff383dc0a6c3-20220908-064942-639462-2-python-flask-env
  registry file: /.conda/environments.txt
done
Installing pip dependencies: ...working... Ran pip subprocess with arguments:
['/var/lib/conda-store/filesystem/459e94e808d08b4f8dac9fe8d327ebeef05d8507fa559ae89050ff383dc0a6c3-20220908-064942-639462-2-python-flask-env/bin/python', '-m', 'pip', 'install', '-U', '-r', '/tmp/tmp7jeo1z6c/condaenv.kyd2xcoc.requirements.txt']
Pip subprocess output:
Collecting nothing
  Downloading nothing-0.0.3-py2.py3-none-any.whl (1.5 kB)
Installing collected packages: nothing
Successfully installed nothing-0.0.3

done
#
# To activate this environment, use
#
#     $ conda activate /var/lib/conda-store/filesystem/459e94e808d08b4f8dac9fe8d327ebeef05d8507fa559ae89050ff383dc0a6c3-20220908-064942-639462-2-python-flask-env
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Retrieving notices: ...working... failed

CondaError: Error encountered while attempting to create cache directory.
  Directory: /.cache/conda/notices
  Exception: [Errno 13] Permission denied: '/.cache'
```