### PR TITLE
WIP: enable faster server reload

### DIFF
--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -11,30 +11,26 @@ RUN apt-get update \
 # we do not want to tamper with the solve
 RUN printf 'channels: []\n' > /opt/conda/.condarc
 
-RUN chown -R 1000:1000 /opt/conda && \
-    mkdir -p /opt/conda-store/conda-store && \
-    chown 1000:1000 /opt/conda-store/conda-store && \
-    mkdir -p /var/lib/conda-store && \
-    chown 1000:1000 /var/lib/conda-store && \
-    mkdir -p /opt/conda-store/envs && \
-    chown 1000:1000 /opt/conda-store/envs && \
-    mkdir /.cache && \
-    chown 1000:1000 /.cache
+RUN mkdir /.cache && chown 1000:1000 /.cache && \
+    chown 1000:1000 /opt && \
+    chown 1000:1000 /opt/conda && \
+    chown 1000:1000 /opt/conda/envs && \
+    mkdir -p /var/lib/conda-store && chown 1000:1000 /var/lib/conda-store && \
+    mkdir -p /opt/conda-store/envs && chown 1000:1000 /opt/conda-store/envs && \
+    mkdir -p /opt/src/tests/assets && chown 1000:1000 /opt/src/tests/assets && \
+    mkdir -p /opt/src/conda-store/conda-store && chown 1000:1000 /opt/src/conda-store/conda-store && \
+    cd /opt && ln -s /opt/src/tests/assets/environments
 
 USER 1000:1000
 
-COPY environment.yaml /opt/conda-store-server/environment.yaml
+COPY environment.yaml /opt/src/conda-store-server/environment.yaml
 
-RUN mamba env create -f /opt/conda-store-server/environment.yaml
+RUN mamba env create -f /opt/src/conda-store-server/environment.yaml
 
-COPY ./ /opt/conda-store-server/
+COPY --chown=1000:1000 ./ /opt/src/conda-store-server/
 
-USER 0:0
-RUN chown -R 1000:1000 /opt/conda-store-server/
-USER 1000:1000
-
-RUN ls -la /opt/conda-store-server/ && \
-    cd /opt/conda-store-server && \
+RUN ls -la /opt/src/conda-store-server/ && \
+    cd /opt/src/conda-store-server && \
     /opt/conda/envs/conda-store-server/bin/pip install .
 
 ENV PATH=/opt/conda/condabin:/opt/conda/envs/conda-store-server/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI, Request, HTTPException
@@ -322,7 +323,8 @@ class CondaStoreServer(Application):
                 app,
                 host=self.address,
                 port=self.port,
-                reload=False,
+                reload=True,
+                reload_dirs = f"{Path(__file__).parent}",
                 workers=1,
                 proxy_headers=self.behind_proxy,
                 forwarded_allow_ips=("*" if self.behind_proxy else None),

--- a/conda-store/Dockerfile
+++ b/conda-store/Dockerfile
@@ -6,15 +6,15 @@ RUN apt-get update \
     && apt-get install -y curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY environment.yaml /opt/conda-store/environment.yaml
+COPY environment.yaml /opt/src/conda-store/environment.yaml
 
-RUN mamba env create -f /opt/conda-store/environment.yaml
+RUN mamba env create -f /opt/src/conda-store/environment.yaml
 
 ENV PATH=/opt/conda/condabin:/opt/conda/envs/conda-store/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}
 
-COPY ./ /opt/conda-store/
+COPY --chown=1000:1000 ./ /opt/src/conda-store/
 
-RUN cd /opt/conda-store && \
+RUN cd /opt/src/conda-store && \
     pip install -e .
 
 RUN mkdir -p /opt/jupyterhub && \

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,0 +1,8 @@
+services:
+  conda-store-worker:
+    volumes:
+      - ./:/opt/src
+
+  conda-store-server:
+    volumes:
+      - ./:/opt/src/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,13 +5,13 @@ services:
     build: conda-store-server
     user: 1000:1000
     volumes:
-      - ./tests/assets/environments:/opt/environments:ro
-      - ./tests/assets/conda_store_config.py:/opt/conda_store/conda_store_config.py:ro
+      - ./tests/assets/environments:/opt/src/tests/assets/environments:ro
+      - ./tests/assets/conda_store_config.py:/opt/src/tests/assets/conda_store_config.py:ro
     depends_on:
       conda-store-server:
         condition: service_healthy
     platform: linux/amd64
-    command: ['conda-store-worker', '--config', '/opt/conda_store/conda_store_config.py']
+    command: ['conda-store-worker', '--config', '/opt/src/tests/assets/conda_store_config.py']
 
   conda-store-server:
     build: conda-store-server
@@ -24,14 +24,14 @@ services:
       redis:
         condition: service_healthy
     volumes:
-      - ./tests/assets/conda_store_config.py:/opt/conda_store/conda_store_config.py:ro
+      - ./tests/assets/conda_store_config.py:/opt/src/tests/assets/conda_store_config.py:ro
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:5000/conda-store/api/v1/"]
       interval: 10s
       timeout: 5s
       retries: 5
     platform: linux/amd64
-    command: ['conda-store-server', '--config', '/opt/conda_store/conda_store_config.py']
+    command: ['conda-store-server', '--config', '/opt/src/tests/assets/conda_store_config.py']
     ports:
       - "5000:5000"
 


### PR DESCRIPTION
Towards resolving #460, this resolves issues with mounting the source into the containers.

This isn't working yet because `uvicorn.run(...,reload=True)` requires that the app argument is specified as a import string, something like "my_package.my_module.app" but currently the app is instantiated within the   `CondaStoreServer.start` method. Perhaps we could return the instantiated app from `CondaStoreServer.__call__`? I haven't worked with fastapi or CondaStoreServer to have a good sense of the best solution.

Also, the Hatch target has not been added yet. 