### PR TITLE
[WIP] adapting to next release of conda-store-ui

### DIFF
--- a/conda-store-server/conda_store_server/server/templates/conda-store-ui.html
+++ b/conda-store-server/conda_store_server/server/templates/conda-store-ui.html
@@ -5,9 +5,7 @@
         <title>conda-store</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script>
-         var GLOBAL_CONDA_STORE_STATE = {
-             NODE_DEBUG: null,
-             REACT_APP_CONTEXT: "single-page-app", // not a true setting
+         var condaStoreConfig = {
              REACT_APP_AUTH_METHOD: "cookie",
              REACT_APP_AUTH_TOKEN: "",
              REACT_APP_STYLE_TYPE: "green-accent",


### PR DESCRIPTION
In [PR 239 on conda-store-ui](https://github.com/Quansight/conda-store-ui/pull/239), we added a mechanism to add a configuration at runtime, and renamed the var `GLOBAL_CONDA_STORE_STATE` to a more javascripty `condaStoreConfig`.

This PR adapts to this change. 

Remaining to do : 
- [ ]  Make a new release of the UI
- [ ] adapt `hatch_build.py` : change the [version number](https://github.com/Quansight/conda-store/blob/ace0269878fb42b186530070df275d4db5c411bc/conda-store-server/hatch_build.py#L12) and [remove the hack here](https://github.com/Quansight/conda-store/blob/ace0269878fb42b186530070df275d4db5c411bc/conda-store-server/hatch_build.py#L61)