### PR TITLE
Update repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ Learn more, including how to install, use, and contribute to conda-store in our 
 
 ## Related repositories
 
-- We are working on a new UI for conda-store at: [`Quansight/conda-store-ui`](https://github.com/Quansight/conda-store-ui), and
-- a JupyterLab extension at: [`Quansight/jupyterlab-conda-store`](https://github.com/Quansight/jupyterlab-conda-store).
+- We are working on a new UI for conda-store at: [`conda-incubator/conda-store-ui`](https://github.com/conda-incubator/conda-store-ui), and
+- a JupyterLab extension at: [`conda-incubator/jupyterlab-conda-store`](https://github.com/conda-incubator/jupyterlab-conda-store).
 
 ## Code of Conduct
 
-To guarantee a welcoming and friendly community, we require all community members to follow our [Code of Conduct](https://github.com/Quansight/.github/blob/master/CODE_OF_CONDUCT.md).
+To guarantee a welcoming and friendly community, we require all community members to follow our [Code of Conduct](https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,11 +8,11 @@ You should feel comfortable upgrading if you're using our documented public APIs
 
 ## Reporting a Vulnerability
 
-If you think you found a vulnerability, please report it at [conda-store/security](https://github.com/Quansight/conda-store/security).
+If you think you found a vulnerability, please report it at [conda-store/security](https://github.com/conda-incubator/conda-store/security).
 
 ## Coverage
 
 This policy covers the following repositories:
-- [conda-store](https://github.com/Quansight/conda-store)
-- [conda-store-ui](https://github.com/Quansight/conda-store-ui)
-- [jupyterlab-conda-store](https://github.com/Quansight/jupyterlab-conda-store)
+- [conda-store](https://github.com/conda-incubator/conda-store)
+- [conda-store-ui](https://github.com/conda-incubator/conda-store-ui)
+- [jupyterlab-conda-store](https://github.com/conda-incubator/jupyterlab-conda-store)

--- a/conda-store-server/conda_store_server/alembic/versions/16f65805dc8f_split_conda_package_into_conda_package_.py
+++ b/conda-store-server/conda_store_server/alembic/versions/16f65805dc8f_split_conda_package_into_conda_package_.py
@@ -227,7 +227,7 @@ def upgrade():
 
     # One case of data inconsistency has been identified, that makes the migration fail :
     #   Dangling build artifacts : rows in table `build_artifact` with a `build_id`` that doesn't exists anymore.
-    #   see issue https://github.com/Quansight/conda-store/issues/476
+    #   see issue https://github.com/conda-incubator/conda-store/issues/476
     # Fix : delete dangling artifacts
     op.execute(
         """ DELETE FROM build_artifact

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -49,7 +49,7 @@ dynamic = ["version"]
 
 [project.urls]
 Homepage = "https://conda.store/"
-Source = "https://github.com/Quansight/conda-store"
+Source = "https://github.com/conda-incubator/conda-store"
 
 [project.optional-dependencies]
 dev = [

--- a/conda-store/pyproject.toml
+++ b/conda-store/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 
 [project.urls]
 Homepage = "https://conda.store/"
-Source = "https://github.com/Quansight/conda-store"
+Source = "https://github.com/conda-incubator/conda-store"
 
 [project.optional-dependencies]
 dev = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/Quansight/conda-store",
+            "url": "https://github.com/conda-incubator/conda-store",
             "icon": "fa-brands fa-github",
         }
    ],

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -121,7 +121,7 @@ easier to contribute to the documentation.
 
 ### Testing
 
-The `conda-store` repository is two packages. 
+The `conda-store` repository is two packages.
  - `conda-store-server/` which is the worker + web server responsible for the `conda-store` service
  - `conda-store/` is the client which interacts with the service
 
@@ -163,7 +163,7 @@ $ cd conda-store-server
 $ hatch env run -e dev lint
 ```
 
-Checking that package builds 
+Checking that package builds
 
 ```shell
 $ cd conda-store-server
@@ -174,7 +174,7 @@ Running unit tests
 
 ```shell
 $ cd conda-store-server
-$ pytest 
+$ pytest
 ```
 
 Running integration tests. These tests are stateful! So you will need
@@ -211,7 +211,7 @@ Once those changes have been made make a commit titled `bump to
 version <version>`.
 
 Finally create a [new release within the GitHub
-interface](https://github.com/Quansight/conda-store/releases/new). Do
+interface](https://github.com/conda-incubator/conda-store/releases/new). Do
 this instead of a git TAG since you can include release notes on the
 repository. The Release should be titled `Release <version> -
 <month>/<day>/<year>` with the description being the changelog
@@ -256,7 +256,7 @@ options were used but eventually we learned that there were too many
 options for the user. Traitlets provides a python configuration file
 that you can use to configure values of the applications. It is used
 for both the server and worker. See
-[`tests/assets/conda_store_config.py`](https://github.com/Quansight/conda-store/blob/main/tests/assets/conda_store_config.py)
+[`tests/assets/conda_store_config.py`](https://github.com/conda-incubator/conda-store/blob/main/tests/assets/conda_store_config.py)
 for a full example.
 
 ### Workers and server
@@ -580,7 +580,7 @@ eralchemy -i "postgresql+psycopg2://admin:password@localhost:5432/conda-store"  
 conda-store relies on [SQLAlchemy](https://www.sqlalchemy.org/) for ORM mapping, and on [Alembic](https://alembic.sqlalchemy.org/en/latest/) for DB migrations.
 
 The procedure to modify the database is the following :
-- First, modify [the ORM Model](https://github.com/Quansight/conda-store/blob/main/conda-store-server/conda_store_server/orm.py) according to the changes you want to make
+- First, modify [the ORM Model](https://github.com/conda-incubator/conda-store/blob/main/conda-store-server/conda_store_server/orm.py) according to the changes you want to make
 - edit the file `conda-store-server/alembic.ini` and replace the value for entry `sqlalchemy.url` to match the connection URL of your database.
 
 - in your command line, run the following :

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Linux
 
-You can install conda-store using conda : 
+You can install conda-store using conda :
 ```shell
 conda install conda-store-server>=0.4.10
 ```
@@ -89,7 +89,7 @@ To install on a local docker daemon there is an existing
 docker-compose up --build
 ```
 
-Then visit via your web browser [https://conda-store.localhost/conda-store](https://conda-store.localhost/conda-store). By default, you can log in with any username and use the password `test`, since [we are using](https://github.com/Quansight/conda-store/blob/a679e5c4d2f2fe7d992fd93c5d90c34b38c513ef/tests/assets/jupyterhub_config.py#L4) the [DummyAuthenticator](https://github.com/jupyterhub/jupyterhub/blob/4e7936056744cdad31d608388a349207196efa56/jupyterhub/auth.py#L1122)
+Then visit via your web browser [https://conda-store.localhost/conda-store](https://conda-store.localhost/conda-store). By default, you can log in with any username and use the password `test`, since [we are using](https://github.com/conda-incubator/conda-store/blob/a679e5c4d2f2fe7d992fd93c5d90c34b38c513ef/tests/assets/jupyterhub_config.py#L4) the [DummyAuthenticator](https://github.com/jupyterhub/jupyterhub/blob/4e7936056744cdad31d608388a349207196efa56/jupyterhub/auth.py#L1122)
 
 ## Local Automated systemd Install
 


### PR DESCRIPTION
This PR is part of https://github.com/conda-incubator/conda-store/issues/514

This PR,

- [x] Changes url that where pointing to `Quansight` org and replace it with `conda-incubator` org.