### PR TITLE
Add python-docker as an explicit dependency in environment.yml

### DIFF
--- a/conda-store-server/environment-dev.yaml
+++ b/conda-store-server/environment-dev.yaml
@@ -7,6 +7,7 @@ dependencies:
   # conda builds
   - conda ==23.5.2
   - conda-docker >= 0.1.2
+  - python-docker
   - conda-pack
   - conda-lock >=1.0.5
   - conda-package-handling

--- a/conda-store-server/environment.yaml
+++ b/conda-store-server/environment.yaml
@@ -5,6 +5,7 @@ dependencies:
   - python ==3.10
   # conda environment builds
   - conda ==23.5.2
+  - python-docker
   - conda-docker >= 0.1.2
   - conda-pack
   - conda-lock >=1.0.5


### PR DESCRIPTION
It is also an implicit dependency of conda-docker, but conda-docker may become an optional dependency for Mac (#507).