### PR TITLE
Adding additional routes for conda-lock lockfile

### DIFF
--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -99,7 +99,7 @@ def build_conda_environment(db: Session, conda_store, build):
                 build.id,
                 build.conda_lock_key,
                 json.dumps(context.result, indent=4).encode("utf-8"),
-                content_type="text/json",
+                content_type="application/json",
                 artifact_type=schema.BuildArtifactType.LOCKFILE,
             )
 

--- a/conda-store-server/conda_store_server/server/templates/build.html
+++ b/conda-store-server/conda_store_server/server/templates/build.html
@@ -68,6 +68,7 @@
         <p>The following build has several methods of running the given environment</p>
     </div>
     <ul class="list-group list-group-flush">
+        <li class="list-group-item"><code>$ micromamba create -n {{ build.environment.name }} -f {{ url_for('api_get_build_conda_lock_file', build_id=build.id) }}</code></li>
         <li class="list-group-item"><code>$ conda-store run {{ build.environment.namespace.name }}/{{ build.environment.name }}:{{ build.id }} -- python</code></li>
         {% if build.has_yaml %}
         <li class="list-group-item">Conda pinned <a href="{{ url_for('api_get_build_yaml', build_id=build.id) }}">environment.yaml</a></li>

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -869,7 +869,11 @@ async def api_get_build_yaml(
     response_class=PlainTextResponse,
 )
 @router_api.get("/build/{build_id}/conda-lock.yml", response_class=PlainTextResponse)
-@router_api.get("/build/{build_id}/conda-lock.yaml", name="api_get_build_conda_lock_file", response_class=PlainTextResponse)
+@router_api.get(
+    "/build/{build_id}/conda-lock.yaml",
+    name="api_get_build_conda_lock_file",
+    response_class=PlainTextResponse,
+)
 @router_api.get("/build/{build_id}/lockfile/", response_class=PlainTextResponse)
 async def api_get_build_lockfile(
     request: Request,
@@ -881,7 +885,9 @@ async def api_get_build_lockfile(
     build_id: int = None,
 ):
     if build_id is None:
-        environment = api.get_environment(db, namespace=namespace, name=environment_name)
+        environment = api.get_environment(
+            db, namespace=namespace, name=environment_name
+        )
         if environment is None:
             raise HTTPException(status_code=404, detail="environment does not exist")
         build = environment.current_build

--- a/tests/assets/conda_store_config.py
+++ b/tests/assets/conda_store_config.py
@@ -10,18 +10,16 @@ c.CondaStore.storage_class = S3Storage
 c.CondaStore.store_directory = "/var/lib/conda-store/"
 c.CondaStore.environment_directory = "/opt/conda-store/envs/{namespace}-{name}"
 # c.CondaStore.database_url = "mysql+pymysql://admin:password@mysql/conda-store"
-c.CondaStore.database_url = "postgresql+psycopg2://postgres:password@postgres/conda-store"
+c.CondaStore.database_url = (
+    "postgresql+psycopg2://postgres:password@postgres/conda-store"
+)
 c.CondaStore.redis_url = "redis://:password@redis:6379/0"
 c.CondaStore.default_uid = 1000
 c.CondaStore.default_gid = 1000
 c.CondaStore.default_permissions = "775"
-c.CondaStore.conda_included_packages = [
-    'ipykernel'
-]
+c.CondaStore.conda_included_packages = ["ipykernel"]
 
-c.CondaStore.pypi_included_packages = [
-    'nothing'
-]
+c.CondaStore.pypi_included_packages = ["nothing"]
 
 
 c.S3Storage.internal_endpoint = "minio:9000"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,22 @@
 import os
 import sys
-sys.path.append(os.path.join(os.getcwd(), 'conda-store-server'))
+
+sys.path.append(os.path.join(os.getcwd(), "conda-store-server"))
 
 import pytest
 from requests import Session
 from urllib.parse import urljoin
 
 
-CONDA_STORE_BASE_URL = os.environ.get('CONDA_STORE_BASE_URL', "http://localhost:5000/conda-store/")
-CONDA_STORE_USERNAME = os.environ.get('CONDA_STORE_USERNAME', "username")
-CONDA_STORE_PASSWORD = os.environ.get('CONDA_STORE_PASSWORD', "password")
+CONDA_STORE_BASE_URL = os.environ.get(
+    "CONDA_STORE_BASE_URL", "http://localhost:5000/conda-store/"
+)
+CONDA_STORE_USERNAME = os.environ.get("CONDA_STORE_USERNAME", "username")
+CONDA_STORE_PASSWORD = os.environ.get("CONDA_STORE_PASSWORD", "password")
 
 
 def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "playwright"
-    )
+    config.addinivalue_line("markers", "playwright")
 
 
 class CondaStoreSession(Session):
@@ -27,11 +28,16 @@ class CondaStoreSession(Session):
         url = urljoin(self.prefix_url, url)
         return super().request(method, url, *args, **kwargs)
 
-    def login(self, username: str = CONDA_STORE_USERNAME, password: str = CONDA_STORE_PASSWORD):
-        response = super().post("login", json={
-            "username": username,
-            "password": password,
-        })
+    def login(
+        self, username: str = CONDA_STORE_USERNAME, password: str = CONDA_STORE_PASSWORD
+    ):
+        response = super().post(
+            "login",
+            json={
+                "username": username,
+                "password": password,
+            },
+        )
         response.raise_for_status()
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,7 +20,7 @@ from conda_store_server import schema
 
 
 def test_api_status_unauth(testclient):
-    response = testclient.get('api/v1/')
+    response = testclient.get("api/v1/")
     response.raise_for_status()
 
     r = schema.APIGetStatus.parse_obj(response.json())
@@ -29,7 +29,7 @@ def test_api_status_unauth(testclient):
 
 
 def test_api_permissions_unauth(testclient):
-    response = testclient.get('api/v1/permission/')
+    response = testclient.get("api/v1/permission/")
     response.raise_for_status()
 
     r = schema.APIGetPermission.parse_obj(response.json())
@@ -37,16 +37,16 @@ def test_api_permissions_unauth(testclient):
     assert r.data.authenticated == False
     assert r.data.primary_namespace == "default"
     assert r.data.entity_permissions == {
-            "default/*": [
-                schema.Permissions.ENVIRONMENT_READ.value,
-                schema.Permissions.NAMESPACE_READ.value,
-            ]
+        "default/*": [
+            schema.Permissions.ENVIRONMENT_READ.value,
+            schema.Permissions.NAMESPACE_READ.value,
+        ]
     }
 
 
 def test_api_permissions_auth(testclient):
     testclient.login()
-    response = testclient.get('api/v1/permission/')
+    response = testclient.get("api/v1/permission/")
     response.raise_for_status()
 
     r = schema.APIGetPermission.parse_obj(response.json())
@@ -54,35 +54,41 @@ def test_api_permissions_auth(testclient):
     assert r.data.authenticated == True
     assert r.data.primary_namespace == "username"
     assert r.data.entity_permissions == {
-        "*/*": sorted([
-            schema.Permissions.ENVIRONMENT_CREATE.value,
-            schema.Permissions.ENVIRONMENT_READ.value,
-            schema.Permissions.ENVIRONMENT_UPDATE.value,
-            schema.Permissions.ENVIRONMENT_DELETE.value,
-            schema.Permissions.ENVIRONMENT_SOLVE.value,
-            schema.Permissions.BUILD_DELETE.value,
-            schema.Permissions.NAMESPACE_CREATE.value,
-            schema.Permissions.NAMESPACE_READ.value,
-            schema.Permissions.NAMESPACE_DELETE.value,
-            schema.Permissions.NAMESPACE_UPDATE.value,
-            schema.Permissions.NAMESPACE_ROLE_MAPPING_CREATE.value,
-            schema.Permissions.NAMESPACE_ROLE_MAPPING_DELETE.value,
-            schema.Permissions.SETTING_READ.value,
-            schema.Permissions.SETTING_UPDATE.value,
-        ]),
-        "default/*": sorted([
-            schema.Permissions.ENVIRONMENT_READ.value,
-            schema.Permissions.NAMESPACE_READ.value,
-        ]),
-        "filesystem/*": sorted([
-            schema.Permissions.ENVIRONMENT_READ.value,
-            schema.Permissions.NAMESPACE_READ.value,
-        ])
+        "*/*": sorted(
+            [
+                schema.Permissions.ENVIRONMENT_CREATE.value,
+                schema.Permissions.ENVIRONMENT_READ.value,
+                schema.Permissions.ENVIRONMENT_UPDATE.value,
+                schema.Permissions.ENVIRONMENT_DELETE.value,
+                schema.Permissions.ENVIRONMENT_SOLVE.value,
+                schema.Permissions.BUILD_DELETE.value,
+                schema.Permissions.NAMESPACE_CREATE.value,
+                schema.Permissions.NAMESPACE_READ.value,
+                schema.Permissions.NAMESPACE_DELETE.value,
+                schema.Permissions.NAMESPACE_UPDATE.value,
+                schema.Permissions.NAMESPACE_ROLE_MAPPING_CREATE.value,
+                schema.Permissions.NAMESPACE_ROLE_MAPPING_DELETE.value,
+                schema.Permissions.SETTING_READ.value,
+                schema.Permissions.SETTING_UPDATE.value,
+            ]
+        ),
+        "default/*": sorted(
+            [
+                schema.Permissions.ENVIRONMENT_READ.value,
+                schema.Permissions.NAMESPACE_READ.value,
+            ]
+        ),
+        "filesystem/*": sorted(
+            [
+                schema.Permissions.ENVIRONMENT_READ.value,
+                schema.Permissions.NAMESPACE_READ.value,
+            ]
+        ),
     }
 
 
 def test_api_list_namespace_unauth(testclient):
-    response = testclient.get('api/v1/namespace')
+    response = testclient.get("api/v1/namespace")
     response.raise_for_status()
 
     r = schema.APIListNamespace.parse_obj(response.json())
@@ -93,7 +99,7 @@ def test_api_list_namespace_unauth(testclient):
 
 def test_api_list_namespace_auth(testclient):
     testclient.login()
-    response = testclient.get('api/v1/namespace')
+    response = testclient.get("api/v1/namespace")
     response.raise_for_status()
 
     r = schema.APIListNamespace.parse_obj(response.json())
@@ -104,7 +110,7 @@ def test_api_list_namespace_auth(testclient):
 
 
 def test_api_get_namespace_unauth(testclient):
-    response = testclient.get('api/v1/namespace/default')
+    response = testclient.get("api/v1/namespace/default")
     response.raise_for_status()
 
     r = schema.APIGetNamespace.parse_obj(response.json())
@@ -113,7 +119,7 @@ def test_api_get_namespace_unauth(testclient):
 
 
 def test_api_get_namespace_unauth_no_exist(testclient):
-    response = testclient.get('api/v1/namespace/wrong')
+    response = testclient.get("api/v1/namespace/wrong")
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -122,7 +128,7 @@ def test_api_get_namespace_unauth_no_exist(testclient):
 
 def test_api_get_namespace_auth(testclient):
     testclient.login()
-    response = testclient.get('api/v1/namespace/filesystem')
+    response = testclient.get("api/v1/namespace/filesystem")
     response.raise_for_status()
 
     r = schema.APIGetNamespace.parse_obj(response.json())
@@ -132,7 +138,7 @@ def test_api_get_namespace_auth(testclient):
 
 def test_api_get_namespace_auth_no_exist(testclient):
     testclient.login()
-    response = testclient.get('api/v1/namespace/wrong')
+    response = testclient.get("api/v1/namespace/wrong")
 
     assert response.status_code == 404
     r = schema.APIResponse.parse_obj(response.json())
@@ -140,7 +146,7 @@ def test_api_get_namespace_auth_no_exist(testclient):
 
 
 def test_api_list_environments_unauth(testclient):
-    response = testclient.get('api/v1/environment')
+    response = testclient.get("api/v1/environment")
     response.raise_for_status()
 
     r = schema.APIListEnvironment.parse_obj(response.json())
@@ -149,7 +155,7 @@ def test_api_list_environments_unauth(testclient):
 
 def test_api_list_environments_auth(testclient):
     testclient.login()
-    response = testclient.get('api/v1/environment')
+    response = testclient.get("api/v1/environment")
     response.raise_for_status()
 
     r = schema.APIListEnvironment.parse_obj(response.json())
@@ -158,7 +164,7 @@ def test_api_list_environments_auth(testclient):
 
 
 def test_api_get_environment_unauth(testclient):
-    response = testclient.get('api/v1/environment/filesystem/python-flask-env')
+    response = testclient.get("api/v1/environment/filesystem/python-flask-env")
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -167,7 +173,7 @@ def test_api_get_environment_unauth(testclient):
 
 def test_api_get_environment_auth_existing(testclient):
     testclient.login()
-    response = testclient.get('api/v1/environment/filesystem/python-flask-env')
+    response = testclient.get("api/v1/environment/filesystem/python-flask-env")
     response.raise_for_status()
 
     r = schema.APIGetEnvironment.parse_obj(response.json())
@@ -178,7 +184,7 @@ def test_api_get_environment_auth_existing(testclient):
 
 def test_api_get_environment_auth_not_existing(testclient):
     testclient.login()
-    response = testclient.get('api/v1/environment/filesystem/wrong')
+    response = testclient.get("api/v1/environment/filesystem/wrong")
     assert response.status_code == 404
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -186,7 +192,7 @@ def test_api_get_environment_auth_not_existing(testclient):
 
 
 def test_api_list_builds_unauth(testclient):
-    response = testclient.get('api/v1/build')
+    response = testclient.get("api/v1/build")
     response.raise_for_status()
 
     r = schema.APIListBuild.parse_obj(response.json())
@@ -195,7 +201,7 @@ def test_api_list_builds_unauth(testclient):
 
 def test_api_list_builds_auth(testclient):
     testclient.login()
-    response = testclient.get('api/v1/build')
+    response = testclient.get("api/v1/build")
     response.raise_for_status()
 
     r = schema.APIListBuild.parse_obj(response.json())
@@ -204,7 +210,7 @@ def test_api_list_builds_auth(testclient):
 
 
 def test_api_get_build_one_unauth(testclient):
-    response = testclient.get('api/v1/build/1')
+    response = testclient.get("api/v1/build/1")
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -213,7 +219,7 @@ def test_api_get_build_one_unauth(testclient):
 
 def test_api_get_build_one_auth(testclient):
     testclient.login()
-    response = testclient.get('api/v1/build/1')
+    response = testclient.get("api/v1/build/1")
     response.raise_for_status()
 
     r = schema.APIGetBuild.parse_obj(response.json())
@@ -224,7 +230,7 @@ def test_api_get_build_one_auth(testclient):
 
 
 def test_api_get_build_one_unauth_packages(testclient):
-    response = testclient.get('api/v1/build/1/packages')
+    response = testclient.get("api/v1/build/1/packages")
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -233,7 +239,7 @@ def test_api_get_build_one_unauth_packages(testclient):
 
 def test_api_get_build_one_auth_packages(testclient):
     testclient.login()
-    response = testclient.get('api/v1/build/1/packages?size=5')
+    response = testclient.get("api/v1/build/1/packages?size=5")
     response.raise_for_status()
 
     r = schema.APIListCondaPackage.parse_obj(response.json())
@@ -243,7 +249,7 @@ def test_api_get_build_one_auth_packages(testclient):
 
 def test_api_get_build_auth_packages_no_exist(testclient):
     testclient.login()
-    response = testclient.get('api/v1/build/101010101/packages')
+    response = testclient.get("api/v1/build/101010101/packages")
     assert response.status_code == 404
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -251,7 +257,7 @@ def test_api_get_build_auth_packages_no_exist(testclient):
 
 
 def test_api_get_build_one_unauth_logs(testclient):
-    response = testclient.get('api/v1/build/1/logs')
+    response = testclient.get("api/v1/build/1/logs")
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -260,31 +266,68 @@ def test_api_get_build_one_unauth_logs(testclient):
 
 def test_api_get_build_one_auth_logs(testclient):
     testclient.login()
-    response = testclient.get('api/v1/build/1/logs')
+    response = testclient.get("api/v1/build/1/logs")
     response.raise_for_status()
 
-    logs = response.content.decode('utf-8')
+    logs = response.content.decode("utf-8")
     assert "Preparing transaction:" in logs
     assert "Executing transaction:" in logs
 
 
 def test_api_get_build_auth_logs_no_exist(testclient):
     testclient.login()
-    response = testclient.get('api/v1/build/10101010101/logs')
+    response = testclient.get("api/v1/build/10101010101/logs")
     assert response.status_code == 404
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "api/v1/environment/filesystem/python-flask-env/lockfile/",
+        "api/v1/environment/filesystem/python-flask-env/conda-lock.yml",
+        "api/v1/environment/filesystem/python-flask-env/conda-lock.yaml",
+        "api/v1/build/1/lockfile/",
+        "api/v1/build/1/conda-lock.yml",
+        "api/v1/build/1/conda-lock.yaml",
+    ],
+)
+def test_api_get_build_one_unauth_lockfile(testclient, url):
+    response = testclient.get(url)
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "api/v1/environment/filesystem/python-flask-env/lockfile/",
+        "api/v1/environment/filesystem/python-flask-env/conda-lock.yml",
+        "api/v1/environment/filesystem/python-flask-env/conda-lock.yaml",
+        "api/v1/build/1/lockfile/",
+        "api/v1/build/1/conda-lock.yml",
+        "api/v1/build/1/conda-lock.yaml",
+    ],
+)
+def test_api_get_build_one_auth_lockfil(testclient, url):
+    testclient.login()
+    response = testclient.get(url)
+    response.raise_for_status()
+
+    lockfile = json.loads(response.content.decode("utf-8"))
+    assert "metadata" in lockfile
+    assert "package" in lockfile
+
+
 def test_api_get_build_one_unauth_yaml(testclient):
-    response = testclient.get('api/v1/build/1/yaml/')
+    response = testclient.get("api/v1/build/1/yaml/")
     assert response.status_code == 403
 
 
 def test_api_get_build_one_auth_yaml(testclient):
     testclient.login()
-    response = testclient.get('api/v1/build/1/yaml/')
+    response = testclient.get("api/v1/build/1/yaml/")
     response.raise_for_status()
 
-    environment_yaml = response.content.decode('utf-8')
+    environment_yaml = response.content.decode("utf-8")
     assert "name:" in environment_yaml
     assert "channels:" in environment_yaml
     assert "dependencies:" in environment_yaml
@@ -292,7 +335,7 @@ def test_api_get_build_one_auth_yaml(testclient):
 
 def test_api_get_build_two_auth(testclient):
     testclient.login()
-    response = testclient.get('api/v1/build/1010101010101')
+    response = testclient.get("api/v1/build/1010101010101")
     response.status_code == 404
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -300,21 +343,21 @@ def test_api_get_build_two_auth(testclient):
 
 
 def test_api_list_conda_channels_unauth(testclient):
-    response = testclient.get('api/v1/channel')
+    response = testclient.get("api/v1/channel")
     response.raise_for_status()
 
     r = schema.APIListCondaChannel.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
     api_channels = set(_.name for _ in r.data)
     assert api_channels == {
-        'https://conda.anaconda.org/main',
-        'https://repo.anaconda.com/pkgs/main',
-        'https://conda.anaconda.org/conda-forge',
+        "https://conda.anaconda.org/main",
+        "https://repo.anaconda.com/pkgs/main",
+        "https://conda.anaconda.org/conda-forge",
     }
 
 
 def test_api_list_conda_packages_unauth(testclient):
-    response = testclient.get('api/v1/package?size=15')
+    response = testclient.get("api/v1/package?size=15")
     response.raise_for_status()
 
     r = schema.APIListCondaPackage.parse_obj(response.json())
@@ -324,16 +367,18 @@ def test_api_list_conda_packages_unauth(testclient):
 
 # ============ MODIFICATION =============
 
-def test_create_specification_uauth(testclient):
-    namespace = 'default'
-    environment_name = f'pytest-{uuid.uuid4()}'
 
-    response = testclient.post('api/v1/specification', json={
-        'namespace': namespace,
-        'specification': json.dumps({
-            'name': environment_name
-        })
-    })
+def test_create_specification_uauth(testclient):
+    namespace = "default"
+    environment_name = f"pytest-{uuid.uuid4()}"
+
+    response = testclient.post(
+        "api/v1/specification",
+        json={
+            "namespace": namespace,
+            "specification": json.dumps({"name": environment_name}),
+        },
+    )
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -341,23 +386,24 @@ def test_create_specification_uauth(testclient):
 
 
 def test_create_specification_auth(testclient):
-    namespace = 'default'
-    environment_name = f'pytest-{uuid.uuid4()}'
+    namespace = "default"
+    environment_name = f"pytest-{uuid.uuid4()}"
 
     testclient.login()
-    response = testclient.post('api/v1/specification', json={
-        'namespace': namespace,
-        'specification': json.dumps({
-            'name': environment_name
-        })
-    })
+    response = testclient.post(
+        "api/v1/specification",
+        json={
+            "namespace": namespace,
+            "specification": json.dumps({"name": environment_name}),
+        },
+    )
     response.raise_for_status()
 
     r = schema.APIPostSpecification.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
 
     # check for the given build
-    response = testclient.get(f'api/v1/build/{r.data.build_id}')
+    response = testclient.get(f"api/v1/build/{r.data.build_id}")
     response.raise_for_status()
 
     r = schema.APIGetBuild.parse_obj(response.json())
@@ -365,7 +411,7 @@ def test_create_specification_auth(testclient):
     assert r.data.specification.name == environment_name
 
     # check for the given environment
-    response = testclient.get(f'api/v1/environment/{namespace}/{environment_name}')
+    response = testclient.get(f"api/v1/environment/{namespace}/{environment_name}")
     response.raise_for_status()
 
     r = schema.APIGetEnvironment.parse_obj(response.json())
@@ -373,22 +419,21 @@ def test_create_specification_auth(testclient):
 
 
 def test_create_specification_auth_no_namespace_specified(testclient):
-    namespace = 'username' # same as login username
-    environment_name = f'pytest-{uuid.uuid4()}'
+    namespace = "username"  # same as login username
+    environment_name = f"pytest-{uuid.uuid4()}"
 
     testclient.login()
-    response = testclient.post('api/v1/specification', json={
-        'specification': json.dumps({
-            'name': environment_name
-        })
-    })
+    response = testclient.post(
+        "api/v1/specification",
+        json={"specification": json.dumps({"name": environment_name})},
+    )
     response.raise_for_status()
 
     r = schema.APIPostSpecification.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
 
     # check for the given build
-    response = testclient.get(f'api/v1/build/{r.data.build_id}')
+    response = testclient.get(f"api/v1/build/{r.data.build_id}")
     response.raise_for_status()
 
     r = schema.APIGetBuild.parse_obj(response.json())
@@ -396,7 +441,7 @@ def test_create_specification_auth_no_namespace_specified(testclient):
     assert r.data.specification.name == environment_name
 
     # check for the given environment
-    response = testclient.get(f'api/v1/environment/{namespace}/{environment_name}')
+    response = testclient.get(f"api/v1/environment/{namespace}/{environment_name}")
     response.raise_for_status()
 
     r = schema.APIGetEnvironment.parse_obj(response.json())
@@ -406,7 +451,7 @@ def test_create_specification_auth_no_namespace_specified(testclient):
 def test_put_build_trigger_build_noauth(testclient):
     build_id = 1
 
-    response = testclient.put(f'api/v1/build/{build_id}')
+    response = testclient.put(f"api/v1/build/{build_id}")
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -417,11 +462,11 @@ def test_put_build_trigger_build_auth(testclient):
     build_id = 1
 
     testclient.login()
-    response = testclient.put(f'api/v1/build/{build_id}')
+    response = testclient.put(f"api/v1/build/{build_id}")
     r = schema.APIPostSpecification.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
 
-    response = testclient.get(f'api/v1/build/{r.data.build_id}')
+    response = testclient.get(f"api/v1/build/{r.data.build_id}")
     response.raise_for_status()
 
     r = schema.APIGetBuild.parse_obj(response.json())
@@ -456,47 +501,49 @@ def test_create_namespace_auth(testclient):
     assert r.data.name == namespace
 
 
-
 def test_update_namespace_noauth(testclient):
     namespace = f"filesystem"
     # namespace = f"pytest-{uuid.uuid4()}"
 
-    test_role_mappings = {f"{namespace}/*":['viewer'],
-                          f"{namespace}/admin":['admin'],
-                          f"{namespace}/test":['admin', 'viewer', 'developer'],
-                        }
+    test_role_mappings = {
+        f"{namespace}/*": ["viewer"],
+        f"{namespace}/admin": ["admin"],
+        f"{namespace}/test": ["admin", "viewer", "developer"],
+    }
 
     # Updates the metadata only
-    response = testclient.put(f"api/v1/namespace/{namespace}/", json={
-        "metadata": {"test_key1":"test_value1", "test_key2":"test_value2"},
-
-    })
+    response = testclient.put(
+        f"api/v1/namespace/{namespace}/",
+        json={
+            "metadata": {"test_key1": "test_value1", "test_key2": "test_value2"},
+        },
+    )
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
     assert r.status == schema.APIStatus.ERROR
-
 
     # Updates the role mappings only
-    response = testclient.put(f"api/v1/namespace/{namespace}", json={
-        "role_mappings": test_role_mappings
-    })
+    response = testclient.put(
+        f"api/v1/namespace/{namespace}", json={"role_mappings": test_role_mappings}
+    )
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
     assert r.status == schema.APIStatus.ERROR
-
 
     # Updates both the metadata and the role mappings
-    response = testclient.put(f"api/v1/namespace/{namespace}", json={
-        "metadata": {"test_key1":"test_value1", "test_key2":"test_value2"},
-        "role_mappings": test_role_mappings
-    })
+    response = testclient.put(
+        f"api/v1/namespace/{namespace}",
+        json={
+            "metadata": {"test_key1": "test_value1", "test_key2": "test_value2"},
+            "role_mappings": test_role_mappings,
+        },
+    )
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
     assert r.status == schema.APIStatus.ERROR
-
 
 
 def test_update_namespace_auth(testclient):
@@ -504,42 +551,43 @@ def test_update_namespace_auth(testclient):
 
     testclient.login()
 
-
-
-    test_role_mappings = {f"{namespace}/*":['viewer'],
-                          f"{namespace}/admin":['admin'],
-                          f"{namespace}/test":['admin', 'viewer', 'developer'],
-                        }
+    test_role_mappings = {
+        f"{namespace}/*": ["viewer"],
+        f"{namespace}/admin": ["admin"],
+        f"{namespace}/test": ["admin", "viewer", "developer"],
+    }
 
     # Updates both the metadata and the role mappings
-    response = testclient.put(f"api/v1/namespace/{namespace}", json={
-        "metadata": {"test_key1":"test_value1", "test_key2":"test_value2"},
-        "role_mappings": test_role_mappings,
-    })
+    response = testclient.put(
+        f"api/v1/namespace/{namespace}",
+        json={
+            "metadata": {"test_key1": "test_value1", "test_key2": "test_value2"},
+            "role_mappings": test_role_mappings,
+        },
+    )
 
     r = schema.APIResponse.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
 
-
     # Updates the metadata only
-    response = testclient.put(f"api/v1/namespace/{namespace}/", json={
-        "metadata": {"test_key1":"test_value1", "test_key2":"test_value2"},
-
-    })
+    response = testclient.put(
+        f"api/v1/namespace/{namespace}/",
+        json={
+            "metadata": {"test_key1": "test_value1", "test_key2": "test_value2"},
+        },
+    )
     response.raise_for_status()
 
     r = schema.APIResponse.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
 
-
     # Updates the role mappings only
-    response = testclient.put(f"api/v1/namespace/{namespace}", json={
-        "role_mappings": test_role_mappings
-    })
+    response = testclient.put(
+        f"api/v1/namespace/{namespace}", json={"role_mappings": test_role_mappings}
+    )
 
     r = schema.APIResponse.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
-
 
 
 def test_create_get_delete_namespace_auth(testclient):
@@ -577,9 +625,9 @@ def test_update_environment_build_unauth(testclient):
     name = "python-flask-env"
     build_id = 1
 
-    response = testclient.put(f'api/v1/environment/{namespace}/{name}', json={
-        "build_id": build_id
-    })
+    response = testclient.put(
+        f"api/v1/environment/{namespace}/{name}", json={"build_id": build_id}
+    )
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -592,15 +640,15 @@ def test_update_environment_build_auth(testclient):
     build_id = 1
 
     testclient.login()
-    response = testclient.put(f'api/v1/environment/{namespace}/{name}', json={
-        "build_id": build_id
-    })
+    response = testclient.put(
+        f"api/v1/environment/{namespace}/{name}", json={"build_id": build_id}
+    )
     response.raise_for_status()
 
     r = schema.APIAckResponse.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
 
-    response = testclient.get(f'api/v1/environment/{namespace}/{name}')
+    response = testclient.get(f"api/v1/environment/{namespace}/{name}")
     response.raise_for_status()
 
     r = schema.APIGetEnvironment.parse_obj(response.json())
@@ -612,7 +660,7 @@ def test_delete_environment_unauth(testclient):
     namespace = "filesystem"
     name = "python-flask-env"
 
-    response = testclient.delete(f'api/v1/environment/{namespace}/{name}')
+    response = testclient.delete(f"api/v1/environment/{namespace}/{name}")
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -620,22 +668,23 @@ def test_delete_environment_unauth(testclient):
 
 
 def test_delete_environment_auth(testclient):
-    namespace = 'default'
-    environment_name = f'pytest-delete-environment-{uuid.uuid4()}'
+    namespace = "default"
+    environment_name = f"pytest-delete-environment-{uuid.uuid4()}"
 
     testclient.login()
-    response = testclient.post('api/v1/specification', json={
-        'namespace': namespace,
-        'specification': json.dumps({
-            'name': environment_name
-        })
-    })
+    response = testclient.post(
+        "api/v1/specification",
+        json={
+            "namespace": namespace,
+            "specification": json.dumps({"name": environment_name}),
+        },
+    )
     response.raise_for_status()
 
     r = schema.APIAckResponse.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
 
-    response = testclient.delete(f'api/v1/environment/{namespace}/{environment_name}')
+    response = testclient.delete(f"api/v1/environment/{namespace}/{environment_name}")
     response.raise_for_status()
 
     r = schema.APIAckResponse.parse_obj(response.json())
@@ -645,7 +694,7 @@ def test_delete_environment_auth(testclient):
 def test_delete_build_unauth(testclient):
     build_id = 1
 
-    response = testclient.delete(f'api/v1/build/{build_id}')
+    response = testclient.delete(f"api/v1/build/{build_id}")
     assert response.status_code == 403
 
     r = schema.APIResponse.parse_obj(response.json())
@@ -656,13 +705,13 @@ def test_delete_build_auth(testclient):
     build_id = 1
 
     testclient.login()
-    response = testclient.put(f'api/v1/build/{build_id}')
+    response = testclient.put(f"api/v1/build/{build_id}")
     r = schema.APIPostSpecification.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
 
     new_build_id = r.data.build_id
 
-    response = testclient.get(f'api/v1/build/{new_build_id}')
+    response = testclient.get(f"api/v1/build/{new_build_id}")
     response.raise_for_status()
 
     r = schema.APIGetBuild.parse_obj(response.json())
@@ -670,7 +719,7 @@ def test_delete_build_auth(testclient):
 
     # currently you cannot delete a build before it succeeds or fails
     # realistically you should be able to delete a build
-    response = testclient.delete(f'api/v1/build/{new_build_id}')
+    response = testclient.delete(f"api/v1/build/{new_build_id}")
     assert response.status_code == 400
 
     # r = schema.APIAckResponse.parse_obj(response.json())

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,15 +1,22 @@
 def test_metrics(testclient):
-    response = testclient.get('metrics')
-    d = {line.split()[0]: line.split()[1] for line in response.content.decode('utf-8').split('\n')}
-    assert {'conda_store_disk_free', 'conda_store_disk_total', 'conda_store_disk_usage'} <= d.keys()
+    response = testclient.get("metrics")
+    d = {
+        line.split()[0]: line.split()[1]
+        for line in response.content.decode("utf-8").split("\n")
+    }
+    assert {
+        "conda_store_disk_free",
+        "conda_store_disk_total",
+        "conda_store_disk_usage",
+    } <= d.keys()
 
 
 def test_celery(testclient):
-    response = testclient.get('celery')
+    response = testclient.get("celery")
     assert response.json().keys() == {
-        'active_tasks',
-        'availability',
-        'registered_tasks',
-        'scheduled_tasks',
-        'stats',
+        "active_tasks",
+        "availability",
+        "registered_tasks",
+        "scheduled_tasks",
+        "stats",
     }

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -15,32 +15,32 @@ def test_integration(page: Page):
     # expect(page).to_have_url("http://localhost:5000/conda-store/login/")
 
     # Click [placeholder="Username"]
-    page.locator("[placeholder=\"Username\"]").click()
+    page.locator('[placeholder="Username"]').click()
 
     # Fill [placeholder="Username"]
-    page.locator("[placeholder=\"Username\"]").fill("username")
+    page.locator('[placeholder="Username"]').fill("username")
 
     # Press Tab
-    page.locator("[placeholder=\"Username\"]").press("Tab")
+    page.locator('[placeholder="Username"]').press("Tab")
 
     # Fill [placeholder="Password"]
-    page.locator("[placeholder=\"Password\"]").fill("password")
+    page.locator('[placeholder="Password"]').fill("password")
 
     # Click button:has-text("Sign In")
     # with page.expect_navigation(url="http://localhost:5000/conda-store/"):
     with page.expect_navigation():
-        page.locator("button:has-text(\"Sign In\")").click()
+        page.locator('button:has-text("Sign In")').click()
 
     page.screenshot(path="test-results/conda-store-authenticated.png")
 
     # Click [placeholder="Search"]
-    page.locator("[placeholder=\"Search\"]").click()
+    page.locator('[placeholder="Search"]').click()
 
     # Fill [placeholder="Search"]
-    page.locator("[placeholder=\"Search\"]").fill("python")
+    page.locator('[placeholder="Search"]').fill("python")
 
     # Press Enter
-    page.locator("[placeholder=\"Search\"]").press("Enter")
+    page.locator('[placeholder="Search"]').press("Enter")
     # expect(page).to_have_url("http://localhost:5000/conda-store/?search=python")
 
     # Click text=filesystem/python-flask-env


### PR DESCRIPTION
Most routes are added as shorthands additionally conda-lock.yaml/yml added for conda-lock compatibility.

Closes issue https://github.com/conda-incubator/conda-store/issues/517