### PR TITLE
Using scoped session to ensure single connection per thread

### DIFF
--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import (
 )
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session
 
 from conda_store_server import utils, schema
 from conda_store_server.environment import validate_environment
@@ -690,5 +691,5 @@ class KeyValueStore(Base):
 def new_session_factory(url="sqlite:///:memory:", reset=False, **kwargs):
     engine = create_engine(url, **kwargs)
 
-    session_factory = sessionmaker(bind=engine)
+    session_factory = scoped_session(sessionmaker(bind=engine))
     return session_factory

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -17,7 +17,7 @@ import yarl
 
 from conda_store_server import schema, orm, utils
 from conda_store_server.server import dependencies
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import scoped_session
 
 
 ARN_ALLOWED_REGEX = re.compile(schema.ARN_ALLOWED)
@@ -113,7 +113,7 @@ class RBACAuthorizationBackend(LoggingConfigurable):
     )
 
     authentication_db = Instance(
-        sessionmaker,
+        scoped_session,
         help="SQLAlchemy session to query DB. Used for role mapping",
         config=False,
     )
@@ -291,7 +291,7 @@ class Authentication(LoggingConfigurable):
     )
 
     authentication_db = Instance(
-        sessionmaker,
+        scoped_session,
         help="SQLAlchemy session to query DB. Used for role mapping",
         config=False,
     )


### PR DESCRIPTION
Using scoped sessions avoids creating excess connections.