### PR TITLE
Adding support for cleaning up builds stuck in BUILDING state

### DIFF
--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -24,8 +24,8 @@ from filelock import FileLock
 def at_start(sender, **k):
     with sender.app.connection():
         sender.app.send_task("task_update_conda_channels")
-        # sender.app.send_task("task_update_storage_metrics")
         sender.app.send_task("task_watch_paths")
+        sender.app.send_task("task_cleanup_builds")
 
 
 class WorkerTask(Task):
@@ -75,6 +75,12 @@ def task_update_storage_metrics(self):
         conda_store.configuration(db).update_storage_metrics(
             db, conda_store.store_directory
         )
+
+
+
+@shared_task(base=WorkerTask, name="task_cleanup_builds")
+def task_cleanup_builds(self):
+    conda_store = self.worker.conda_store
 
 
 """

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -8,6 +8,7 @@ import yaml
 from conda_store_server.worker.app import CondaStoreWorker
 from conda_store_server import api, environment, utils, schema
 from conda_store_server.build import (
+    build_cleanup,
     build_conda_environment,
     build_conda_env_export,
     build_conda_pack,
@@ -77,10 +78,11 @@ def task_update_storage_metrics(self):
         )
 
 
-
-@shared_task(base=WorkerTask, name="task_cleanup_builds")
+@shared_task(base=WorkerTask, name="task_cleanup_builds", bind=True)
 def task_cleanup_builds(self):
     conda_store = self.worker.conda_store
+    with conda_store.session_factory() as db:
+        build_cleanup(db, conda_store)
 
 
 """

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -536,3 +536,16 @@ File "/opt/conda/envs/conda-store-server/lib/python3.9/site-packages/billiard/po
 
 billiard.exceptions.WorkerLostError: Worker exited prematurely: signal 9 (SIGKILL) Job: 348.
 ```
+
+### Why are environment builds stuck in building state?
+
+Recently conda-store added a feature to cleanup builds which are stuck
+in the BUILDING state and are not currently running on the
+workers. This feature only works for certain brokers
+e.g. redis. Database celery brokers are not supported.
+
+This issue occurs when the worker spontaineously dies. This can happen
+for several reasons:
+ - worker is killed due to consuming too much memory (conda solver/builds can consume a lot of memory)
+ - worker was killed for other reasons e.g. forced restart
+ - bugs in conda-store


### PR DESCRIPTION
Celery broker support varies for inspecting active tasks. The redis backend has great support for this feature. If you use the sqlalchemy backend it will not support inspecting active tasks.


Closes https://github.com/conda-incubator/conda-store/issues/170
Closes https://github.com/conda-incubator/conda-store/issues/171
