### PR TITLE
Adding build canceling (only works with compatible celery brokers redis and rabbitmq)

### DIFF
--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -688,6 +688,8 @@ class CondaStore(LoggingConfigurable):
         # must import tasks after a celery app has been initialized
         from conda_store_server.worker import tasks
 
+        # Note: task ids used here must also be in api_put_build_cancel
+
         artifact_tasks = []
         if schema.BuildArtifactType.YAML in settings.build_artifacts:
             artifact_tasks.append(

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -64,12 +64,24 @@ def set_build_completed(db: Session, conda_store, build: orm.Build):
     db.commit()
 
 
-def build_cleanup(db: Session, conda_store):
+def build_cleanup(
+    db: Session,
+    conda_store,
+    build_ids: typing.List[str] = None,
+    reason: str = None
+):
     """Walk through all builds in BUILDING state and check that they are actively running
 
     Build can get stuck in the building state due to worker
     spontaineously dying due to memory errors, killing container, etc.
     """
+    reason = reason or """
+Build marked as FAILED on cleanup due to being stuck in BUILDING state
+and not present on workers. This happens for several reasons: build is
+canceled, a worker crash from out of memory errors, worker was killed,
+or error in conda-store
+"""
+
     inspect = conda_store.celery_app.control.inspect()
     active_tasks = inspect.active()
     if active_tasks is None:
@@ -86,10 +98,14 @@ def build_cleanup(db: Session, conda_store):
                 build_id, name = match.groups()
                 build_active_tasks[build_id].append(task["name"])
 
-    for build in api.list_builds(db, status=schema.BuildStatus.BUILDING):
-        if str(build.id) not in build_active_tasks and build.started_on < (
-            datetime.datetime.utcnow() - datetime.timedelta(seconds=5)
-        ):
+    if build_ids:
+        builds = [api.get_build(db, build_id) for build_id in build_ids]
+    else:
+        builds = api.list_builds(db, status=schema.BuildStatus.BUILDING)
+
+    for build in builds:
+        if build.status == schema.BuildStatus.BUILDING and str(build.id) not in build_active_tasks and (
+                build.started_on < (datetime.datetime.utcnow() - datetime.timedelta(seconds=5))):
             conda_store.log.warning(
                 f"marking build {build.id} as FAILED since stuck in BUILDING state and not present on workers"
             )
@@ -97,11 +113,7 @@ def build_cleanup(db: Session, conda_store):
                 db,
                 conda_store,
                 build,
-                """
-Build marked as FAILED on cleanup due to being stuck in BUILDING state
-and not present on workers. This happens for several reasons: from a
-worker crash usually out of memory, worker was killed, or error in conda-store
-""",
+                reason,
             )
             set_build_failed(db, build)
 

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -33,6 +33,7 @@ class Permissions(enum.Enum):
     ENVIRONMENT_UPDATE = "environment::update"
     ENVIRONMENT_DELETE = "environment::delete"
     ENVIRONMENT_SOLVE = "environment::solve"
+    BUILD_CANCEL = "build::cancel"
     BUILD_DELETE = "build::delete"
     NAMESPACE_CREATE = "namespace::create"
     NAMESPACE_READ = "namespace::read"

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -146,6 +146,7 @@ class RBACAuthorizationBackend(LoggingConfigurable):
                 schema.Permissions.NAMESPACE_ROLE_MAPPING_READ,
             },
             "developer": {
+                schema.Permissions.BUILD_CANCEL,
                 schema.Permissions.ENVIRONMENT_CREATE,
                 schema.Permissions.ENVIRONMENT_READ,
                 schema.Permissions.ENVIRONMENT_UPDATE,
@@ -156,6 +157,7 @@ class RBACAuthorizationBackend(LoggingConfigurable):
             },
             "admin": {
                 schema.Permissions.BUILD_DELETE,
+                schema.Permissions.BUILD_CANCEL,
                 schema.Permissions.ENVIRONMENT_CREATE,
                 schema.Permissions.ENVIRONMENT_DELETE,
                 schema.Permissions.ENVIRONMENT_READ,

--- a/conda-store-server/conda_store_server/server/templates/base.html
+++ b/conda-store-server/conda_store_server/server/templates/base.html
@@ -24,7 +24,8 @@
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
 
         <!-- icons -->
-        <script src="https://unpkg.com/ionicons@5.1.2/dist/ionicons.js"></script>
+        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
+        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
 
         <!-- Initialize popovers globally -->
         <script>

--- a/conda-store-server/conda_store_server/server/templates/environment.html
+++ b/conda-store-server/conda_store_server/server/templates/environment.html
@@ -46,6 +46,11 @@
                 <ion-icon name="trash"></ion-icon>
             </button>
             {% endif %}
+            {% if build.status.value in ["BUILDING"] %}
+            <button type="button" data-action="cancel" data-id="{{ build.id }}" class="btn btn-primary mb-2">
+                <ion-icon name="ban-outline"></ion-icon>
+            </button>
+            {% endif %}
         </div>
     </li>
     {% endfor %}
@@ -115,6 +120,21 @@
      }
  }
 
+ async function cancelBuild(event) {
+     event.preventDefault();
+     let buildId = event.currentTarget.getAttribute('data-id');
+
+     let url = `{{ url_for('api_list_builds') }}${ buildId }/cancel/`;
+     let response = await fetch(url, { method: 'PUT' });
+
+     if (response.ok) {
+         window.location.reload(true);
+     } else {
+         let data = await response.json();
+         bannerMessage(`<div class="alert alert-danger col">${data.message}</div>`);
+     }
+ }
+
  document.querySelectorAll('button[data-action="set-current"]').forEach(item => {
      item.addEventListener('click', (event) => setCurrentEnvironmentBuild(event));
  })
@@ -125,6 +145,10 @@
 
  document.querySelectorAll('button[data-action="delete"]').forEach(item => {
      item.addEventListener('click', (event) => deleteBuild(event));
+ })
+
+ document.querySelectorAll('button[data-action="cancel"]').forEach(item => {
+     item.addEventListener('click', (event) => cancelBuild(event));
  })
 
  async function deleteEnvironment(event) {

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -958,7 +958,10 @@ async def api_put_build_cancel(
     )
 
     if conda_store.celery_app.control.inspect().ping() is None:
-        raise HTTPException(status_code=409, detail="conda-store celery broker does not support task cancelation. Use redis or rabbitmq message queues. See docs for a more detailed explanation")
+        raise HTTPException(
+            status_code=409,
+            detail="conda-store celery broker does not support task cancelation. Use redis or rabbitmq message queues. See docs for a more detailed explanation",
+        )
 
     conda_store.celery_app.control.revoke(
         [

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -943,50 +943,50 @@ async def api_put_build_cancel(
     build_id: int,
     request: Request,
     conda_store=Depends(dependencies.get_conda_store),
-    db: Session = Depends(dependencies.get_db),
     auth=Depends(dependencies.get_auth),
 ):
-    build = api.get_build(db, build_id)
-    if build is None:
-        raise HTTPException(status_code=404, detail="build id does not exist")
+    with conda_store.get_db() as db:
+        build = api.get_build(db, build_id)
+        if build is None:
+            raise HTTPException(status_code=404, detail="build id does not exist")
 
-    auth.authorize_request(
-        request,
-        f"{build.environment.namespace.name}/{build.environment.name}",
-        {Permissions.BUILD_CANCEL},
-        require=True,
-    )
-
-    if conda_store.celery_app.control.inspect().ping() is None:
-        raise HTTPException(
-            status_code=409,
-            detail="conda-store celery broker does not support task cancelation. Use redis or rabbitmq message queues. See docs for a more detailed explanation",
+        auth.authorize_request(
+            request,
+            f"{build.environment.namespace.name}/{build.environment.name}",
+            {Permissions.BUILD_CANCEL},
+            require=True,
         )
 
-    conda_store.celery_app.control.revoke(
-        [
-            f"build-{build_id}-conda-env-export",
-            f"build-{build_id}-conda-pack",
-            f"build-{build_id}-conda-docker",
-            f"build-{build_id}-environment",
-        ],
-        terminate=True,
-        signal="SIGTERM",
-    )
+        if conda_store.celery_app.control.inspect().ping() is None:
+            raise HTTPException(
+                status_code=409,
+                detail="conda-store celery broker does not support task cancelation. Use redis or rabbitmq message queues. See docs for a more detailed explanation",
+            )
 
-    from conda_store_server.worker import tasks
+        conda_store.celery_app.control.revoke(
+            [
+                f"build-{build_id}-conda-env-export",
+                f"build-{build_id}-conda-pack",
+                f"build-{build_id}-conda-docker",
+                f"build-{build_id}-environment",
+            ],
+            terminate=True,
+            signal="SIGTERM",
+        )
 
-    tasks.task_cleanup_builds.si(
-        build_ids=[build_id],
-        reason=f"""
-build {build_id} marked as FAILED due to being canceled from the REST API
-""",
-    ).apply_async(countdown=5)
+        from conda_store_server.worker import tasks
 
-    return {
-        "status": "ok",
-        "message": f"build {build_id} canceled",
-    }
+        tasks.task_cleanup_builds.si(
+            build_ids=[build_id],
+            reason=f"""
+    build {build_id} marked as FAILED due to being canceled from the REST API
+    """,
+        ).apply_async(countdown=5)
+
+        return {
+            "status": "ok",
+            "message": f"build {build_id} canceled",
+        }
 
 
 @router_api.delete(

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -957,6 +957,9 @@ async def api_put_build_cancel(
         require=True,
     )
 
+    if conda_store.celery_app.control.inspect().ping() is None:
+        raise HTTPException(status_code=409, detail="conda-store celery broker does not support task cancelation. Use redis or rabbitmq message queues. See docs for a more detailed explanation")
+
     conda_store.celery_app.control.revoke(
         [
             f"build-{build_id}-conda-env-export",

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -967,7 +967,7 @@ async def api_put_build_cancel(
             [
                 f"build-{build_id}-conda-env-export",
                 f"build-{build_id}-conda-pack",
-                f"build-{build_id}-conda-docker",
+                f"build-{build_id}-docker",
                 f"build-{build_id}-environment",
             ],
             terminate=True,

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -974,6 +974,12 @@ async def api_put_build_cancel(
         signal="SIGTERM",
     )
 
+    from conda_store_server.worker import tasks
+
+    tasks.task_cleanup_builds.si(build_ids=[build_id], reason=f"""
+build {build_id} marked as FAILED due to being canceled from the REST API
+""").apply_async(countdown=5)
+
     return {
         "status": "ok",
         "message": f"build {build_id} canceled",

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -980,6 +980,8 @@ async def api_put_build_cancel(
 
         from conda_store_server.worker import tasks
 
+        # Waits 5 seconds to ensure enough time for the task to actually be
+        # canceled
         tasks.task_cleanup_builds.si(
             build_ids=[build_id],
             reason=f"""

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -935,6 +935,45 @@ async def api_put_build(
         }
 
 
+@router_api.put(
+    "/build/{build_id}/cancel/",
+    response_model=schema.APIAckResponse,
+)
+async def api_put_build_cancel(
+    build_id: int,
+    request: Request,
+    conda_store=Depends(dependencies.get_conda_store),
+    db: Session = Depends(dependencies.get_db),
+    auth=Depends(dependencies.get_auth),
+):
+    build = api.get_build(db, build_id)
+    if build is None:
+        raise HTTPException(status_code=404, detail="build id does not exist")
+
+    auth.authorize_request(
+        request,
+        f"{build.environment.namespace.name}/{build.environment.name}",
+        {Permissions.BUILD_CANCEL},
+        require=True,
+    )
+
+    conda_store.celery_app.control.revoke(
+        [
+            f"build-{build_id}-conda-env-export",
+            f"build-{build_id}-conda-pack",
+            f"build-{build_id}-conda-docker",
+            f"build-{build_id}-environment",
+        ],
+        terminate=True,
+        signal="SIGTERM",
+    )
+
+    return {
+        "status": "ok",
+        "message": f"build {build_id} canceled",
+    }
+
+
 @router_api.delete(
     "/build/{build_id}/",
     response_model=schema.APIAckResponse,

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -960,7 +960,11 @@ async def api_put_build_cancel(
         if conda_store.celery_app.control.inspect().ping() is None:
             raise HTTPException(
                 status_code=409,
-                detail="conda-store celery broker does not support task cancelation. Use redis or rabbitmq message queues. See docs for a more detailed explanation",
+                detail=(
+                    "conda-store celery broker does not support task cancelation. "
+                    "Use redis or rabbitmq message queues. "
+                    "See docs for a more detailed explanation"
+                ),
             )
 
         conda_store.celery_app.control.revoke(

--- a/conda-store-server/conda_store_server/server/views/api.py
+++ b/conda-store-server/conda_store_server/server/views/api.py
@@ -976,9 +976,12 @@ async def api_put_build_cancel(
 
     from conda_store_server.worker import tasks
 
-    tasks.task_cleanup_builds.si(build_ids=[build_id], reason=f"""
+    tasks.task_cleanup_builds.si(
+        build_ids=[build_id],
+        reason=f"""
 build {build_id} marked as FAILED due to being canceled from the REST API
-""").apply_async(countdown=5)
+""",
+    ).apply_async(countdown=5)
 
     return {
         "status": "ok",

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import shutil
+import typing
 
 import yaml
 from celery import Task, shared_task
@@ -78,10 +79,10 @@ def task_update_storage_metrics(self):
 
 
 @shared_task(base=WorkerTask, name="task_cleanup_builds", bind=True)
-def task_cleanup_builds(self):
+def task_cleanup_builds(self, build_ids: typing.List[str] = None, reason: str = None):
     conda_store = self.worker.conda_store
     with conda_store.session_factory() as db:
-        build_cleanup(db, conda_store)
+        build_cleanup(db, conda_store, build_ids, reason)
 
 
 """

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -48,6 +48,7 @@ def test_api_permissions_auth(testclient, authenticate):
                 schema.Permissions.ENVIRONMENT_UPDATE.value,
                 schema.Permissions.ENVIRONMENT_DELETE.value,
                 schema.Permissions.ENVIRONMENT_SOLVE.value,
+                schema.Permissions.BUILD_CANCEL.value,
                 schema.Permissions.BUILD_DELETE.value,
                 schema.Permissions.NAMESPACE_CREATE.value,
                 schema.Permissions.NAMESPACE_READ.value,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -993,7 +993,7 @@ def test_api_cancel_build(testclient):
     r = schema.APIResponse.parse_obj(response.json())
 
     assert r.status == schema.APIStatus.OK
-    assert "canceled" in r.message
+    assert r.message == f"build {new_build_id} canceled"
 
     # delay to ensure the build is marked as failed
     time.sleep(10)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -982,7 +982,7 @@ def test_api_cancel_build_auth(testclient):
 
     new_build_id = r.data.build_id
 
-    # delay to ensure the build kicks off
+    # Delay to ensure the build kicks off
     build_timeout = 180
     building = False
     start = time.time()
@@ -1007,11 +1007,10 @@ def test_api_cancel_build_auth(testclient):
     response = testclient.put(f"api/v1/build/{new_build_id}/cancel")
 
     r = schema.APIResponse.parse_obj(response.json())
-
     assert r.status == schema.APIStatus.OK
     assert r.message == f"build {new_build_id} canceled"
 
-    # delay to ensure the build is marked as failed
+    # Delay to ensure the build is marked as failed
     time.sleep(10)
 
     # Ensure status is Failed

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,7 @@ from typing import List
 import aiohttp
 import conda_store_server
 import pytest
+import requests
 from conda_store_server import schema
 from pydantic import parse_obj_as
 
@@ -976,7 +977,11 @@ def test_api_cancel_build(testclient):
     building = False
     start = time.time()
     while time.time() - start < build_timeout:
-        response = testclient.get(f"api/v1/build/{new_build_id}")
+        try:
+            response = testclient.get(f"api/v1/build/{new_build_id}")
+        except requests.exceptions.ConnectionError:
+            time.sleep(5)
+            continue
         response.raise_for_status()
 
         r = schema.APIGetBuild.parse_obj(response.json())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -972,7 +972,7 @@ def test_api_cancel_build(testclient):
     new_build_id = r.data.build_id
 
     # delay to ensure the build kicks off
-    build_timeout = 120
+    build_timeout = 180
     building = False
     start = time.time()
     while time.time() - start < build_timeout:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -978,3 +978,12 @@ def test_api_cancel_build(testclient):
 
     assert r.status == schema.APIStatus.OK
     assert "canceled" in r.message
+
+    # Ensure status is Failed
+    response = testclient.get(f"api/v1/build/{new_build_id}")
+    response.raise_for_status()
+
+    r = schema.APIGetBuild.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert r.data.id == {new_build_id}
+    assert r.data.status == schema.BuildStatus.FAILED.value

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -970,7 +970,7 @@ def test_api_cancel_build(testclient):
     assert r.status == schema.APIStatus.OK
 
     # delay to ensure the build kicks off
-    time.sleep(30)
+    time.sleep(90)
 
     new_build_id = r.data.build_id
 
@@ -983,7 +983,7 @@ def test_api_cancel_build(testclient):
     assert "canceled" in r.message
 
     # delay to ensure the build is marked as failed
-    time.sleep(30)
+    time.sleep(90)
 
     # Ensure status is Failed
     response = testclient.get(f"api/v1/build/{new_build_id}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1005,6 +1005,7 @@ def test_api_cancel_build_auth(testclient):
 
     # The new build should have kicked off, so now we will request to cancel it
     response = testclient.put(f"api/v1/build/{new_build_id}/cancel")
+    response.raise_for_status()
 
     r = schema.APIResponse.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -996,7 +996,7 @@ def test_api_cancel_build(testclient):
     assert "canceled" in r.message
 
     # delay to ensure the build is marked as failed
-    time.sleep(30)
+    time.sleep(10)
 
     # Ensure status is Failed
     response = testclient.get(f"api/v1/build/{new_build_id}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -985,5 +985,5 @@ def test_api_cancel_build(testclient):
 
     r = schema.APIGetBuild.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
-    assert r.data.id == {new_build_id}
+    assert r.data.id == new_build_id
     assert r.data.status == schema.BuildStatus.FAILED.value

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -969,6 +969,9 @@ def test_api_cancel_build(testclient):
     r = schema.APIPostSpecification.parse_obj(response.json())
     assert r.status == schema.APIStatus.OK
 
+    # delay to ensure the build kicks off
+    time.sleep(30)
+
     new_build_id = r.data.build_id
 
     # The new build should have kicked off, so now we will request to cancel it
@@ -978,6 +981,9 @@ def test_api_cancel_build(testclient):
 
     assert r.status == schema.APIStatus.OK
     assert "canceled" in r.message
+
+    # delay to ensure the build is marked as failed
+    time.sleep(30)
 
     # Ensure status is Failed
     response = testclient.get(f"api/v1/build/{new_build_id}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -959,3 +959,21 @@ def test_delete_build_auth(testclient):
 
     # r = schema.APIResponse.parse_obj(response.json())
     # assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_cancel_build(testclient):
+    build_id = 1
+
+    testclient.login()
+    response = testclient.put(f"api/v1/build/{build_id}")
+    r = schema.APIPostSpecification.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+
+    new_build_id = r.data.build_id
+
+    # The new build should have kicked off, so now we will request to cancel it
+    response = testclient.put(f"api/v1/build/{new_build_id}/cancel")
+
+    r = schema.APIPostSpecification.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    assert "canceled" in r.message

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -974,6 +974,7 @@ def test_api_cancel_build(testclient):
     # The new build should have kicked off, so now we will request to cancel it
     response = testclient.put(f"api/v1/build/{new_build_id}/cancel")
 
-    r = schema.APIPostSpecification.parse_obj(response.json())
+    r = schema.APIResponse.parse_obj(response.json())
+
     assert r.status == schema.APIStatus.OK
     assert "canceled" in r.message

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -962,7 +962,17 @@ def test_delete_build_auth(testclient):
     # assert r.status == schema.APIStatus.ERROR
 
 
-def test_api_cancel_build(testclient):
+def test_api_cancel_build_unauth(testclient):
+    build_id = 1
+
+    response = testclient.put(f"api/v1/build/{build_id}/cancel")
+    assert response.status_code == 403
+
+    r = schema.APIResponse.parse_obj(response.json())
+    assert r.status == schema.APIStatus.ERROR
+
+
+def test_api_cancel_build_auth(testclient):
     build_id = 1
 
     testclient.login()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1017,7 +1017,11 @@ def test_api_cancel_build_auth(testclient):
         time.sleep(5)
 
         # Ensure status is Failed
-        response = testclient.get(f"api/v1/build/{new_build_id}")
+        try:
+            response = testclient.get(f"api/v1/build/{new_build_id}")
+        except requests.exceptions.ConnectionError:
+            time.sleep(5)
+            continue
         response.raise_for_status()
 
         r = schema.APIGetBuild.parse_obj(response.json())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -972,7 +972,7 @@ def test_api_cancel_build(testclient):
     new_build_id = r.data.build_id
 
     # delay to ensure the build kicks off
-    build_timeout = 300
+    build_timeout = 120
     building = False
     start = time.time()
     while time.time() - start < build_timeout:
@@ -996,7 +996,7 @@ def test_api_cancel_build(testclient):
     assert "canceled" in r.message
 
     # delay to ensure the build is marked as failed
-    time.sleep(10)
+    time.sleep(30)
 
     # Ensure status is Failed
     response = testclient.get(f"api/v1/build/{new_build_id}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,6 +104,7 @@ def test_api_permissions_auth(testclient):
                 schema.Permissions.ENVIRONMENT_UPDATE.value,
                 schema.Permissions.ENVIRONMENT_DELETE.value,
                 schema.Permissions.ENVIRONMENT_SOLVE.value,
+                schema.Permissions.BUILD_CANCEL.value,
                 schema.Permissions.BUILD_DELETE.value,
                 schema.Permissions.NAMESPACE_CREATE.value,
                 schema.Permissions.NAMESPACE_READ.value,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -983,7 +983,7 @@ def test_api_cancel_build(testclient):
         if r.data.status == schema.BuildStatus.BUILDING.value:
             building = True
             break
-        time.sleep(30)
+        time.sleep(5)
 
     assert building is True
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -995,6 +995,7 @@ def test_api_cancel_build_auth(testclient):
         response.raise_for_status()
 
         r = schema.APIGetBuild.parse_obj(response.json())
+        assert r.status == schema.APIStatus.OK
         if r.data.status == schema.BuildStatus.BUILDING.value:
             building = True
             break


### PR DESCRIPTION
Closes https://github.com/conda-incubator/conda-store/issues/306

Build canceling exposed at `PUT /api/v1/build/<build-id>/cancel/` and added a new permissions `build::cancel` which is available by default for `admin` and `developer` roles.