### PR TITLE
🔧 Create new docs env

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
 version: 2
 
 conda:
-  environment: conda-store-server/environment-dev.yaml
+  environment: docs/environment-docs.yml

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -1,0 +1,10 @@
+name: conda-store-docs
+channels:
+  - conda-forge
+dependencies:
+  - python ==3.10
+  - sphinx
+  - myst-parser
+  - sphinx-panels
+  - sphinx-copybutton
+  - pydata-sphinx-theme


### PR DESCRIPTION
Addresses #532 (hence, #514)

Read The Docs build have been failing due to conda solve errors: https://readthedocs.org/projects/conda-store/builds/

Currently, we use [conda-store-server/environment-dev](https://github.com/conda-incubator/conda-store/blob/main/conda-store-server/environment-dev.yaml) for the docs build. We only need a subset of libraries for the docs, so adding a simpler YAML in this PR to get the docs building successfully.

Note that this is an intermediate fix to have functioning documentation. The plan is to overhaul the docs and move to Docusaurus - #397 