### PR TITLE
Don't run conda-docker on Mac

### DIFF
--- a/conda-store-server/conda_store_server/action/generate_conda_docker.py
+++ b/conda-store-server/conda_store_server/action/generate_conda_docker.py
@@ -1,12 +1,5 @@
+import sys
 import pathlib
-
-from conda_docker.conda import (
-    build_docker_environment_image,
-    conda_info,
-    fetch_precs,
-    find_user_conda,
-    precs_from_environment_prefix,
-)
 
 from conda_store_server import action
 
@@ -20,6 +13,21 @@ def action_generate_conda_docker(
     output_image_name: str,
     output_image_tag: str,
 ):
+    if sys.platform != "linux":
+        raise RuntimeError(
+            "Generating Docker images is currently only supported on Linux"
+        )
+
+    # Import is inside the function because conda_docker is only available on
+    # Linux
+    from conda_docker.conda import (
+        build_docker_environment_image,
+        conda_info,
+        fetch_precs,
+        find_user_conda,
+        precs_from_environment_prefix,
+    )
+
     user_conda = find_user_conda()
     info = conda_info(user_conda)
     download_dir = info["pkgs_dirs"][0]

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import datetime
 from typing import Any, Dict
 
@@ -240,8 +241,14 @@ class CondaStore(LoggingConfigurable):
             schema.BuildArtifactType.LOCKFILE,
             schema.BuildArtifactType.YAML,
             schema.BuildArtifactType.CONDA_PACK,
-            schema.BuildArtifactType.DOCKER_MANIFEST,
-            schema.BuildArtifactType.CONTAINER_REGISTRY,
+            *(
+                [
+                    schema.BuildArtifactType.DOCKER_MANIFEST,
+                    schema.BuildArtifactType.CONTAINER_REGISTRY,
+                ]
+                if sys.platform == "linux"
+                else []
+            ),
         ],
         help="artifacts to build in conda-store. By default all of the artifacts",
         config=True,
@@ -665,6 +672,7 @@ class CondaStore(LoggingConfigurable):
                     immutable=True,
                 )
             )
+
         if (
             schema.BuildArtifactType.DOCKER_MANIFEST in settings.build_artifacts
             or schema.BuildArtifactType.CONTAINER_REGISTRY in settings.build_artifacts

--- a/conda-store-server/conda_store_server/schema.py
+++ b/conda-store-server/conda_store_server/schema.py
@@ -1,5 +1,6 @@
 import re
 import os
+import sys
 import datetime
 import enum
 from typing import List, Optional, Union, Dict, Any, Callable
@@ -320,8 +321,14 @@ class Settings(BaseModel):
             BuildArtifactType.LOCKFILE,
             BuildArtifactType.YAML,
             BuildArtifactType.CONDA_PACK,
-            BuildArtifactType.DOCKER_MANIFEST,
-            BuildArtifactType.CONTAINER_REGISTRY,
+            *(
+                [
+                    BuildArtifactType.DOCKER_MANIFEST,
+                    BuildArtifactType.CONTAINER_REGISTRY,
+                ]
+                if sys.platform == "linux"
+                else []
+            ),
         ],
         description="artifacts to build in conda-store. By default all of the artifacts",
         metadata={"global": False},


### PR DESCRIPTION
conda-docker doesn't work on Mac, and making it work is not straightforward, so for now we just disable it when we aren't on Linux.

With this and #537, basic Mac support seems to work with --standalone (#507). I'm not sure what else I should be testing, but I can create environments and they appear to be functional.

