### PR TITLE
Make tests use a temporary directory for conda environments

### DIFF
--- a/conda-store-server/tests/test_actions.py
+++ b/conda-store-server/tests/test_actions.py
@@ -93,28 +93,29 @@ def test_install_lockfile(tmp_path, conda_store, simple_conda_lock):
     assert conda_utils.is_conda_prefix(conda_prefix)
 
 
-def test_generate_conda_export(conda_store, current_prefix):
+def test_generate_conda_export(conda_store, conda_prefix):
     context = action.action_generate_conda_export(
-        conda_command=conda_store.conda_command, conda_prefix=current_prefix
+        conda_command=conda_store.conda_command, conda_prefix=conda_prefix
     )
 
     schema.CondaSpecification.parse_obj(context.result)
 
 
-def test_generate_conda_pack(tmp_path, current_prefix):
+def test_generate_conda_pack(tmp_path, conda_prefix):
     output_filename = tmp_path / "environment.tar.gz"
 
     action.action_generate_conda_pack(
-        conda_prefix=current_prefix,
+        conda_prefix=conda_prefix,
         output_filename=output_filename,
     )
 
     assert output_filename.exists()
 
 
-def test_generate_conda_docker(conda_store, current_prefix):
+@pytest.mark.skipif(sys.platform != "linux", reason="conda-docker only works on linux")
+def test_generate_conda_docker(conda_store, conda_prefix):
     action.action_generate_conda_docker(
-        conda_prefix=current_prefix,
+        conda_prefix=conda_prefix,
         default_docker_image=utils.callable_or_value(
             conda_store.default_docker_base_image, None
         ),
@@ -175,16 +176,14 @@ def test_get_conda_prefix_stats(tmp_path, conda_store, simple_conda_lock):
     assert context.result["disk_usage"] > 0
 
 
-def test_add_conda_prefix_packages(
-    db, conda_store, simple_specification, current_prefix
-):
+def test_add_conda_prefix_packages(db, conda_store, simple_specification, conda_prefix):
     build_id = conda_store.register_environment(
         db, specification=simple_specification, namespace="pytest"
     )
 
     action.action_add_conda_prefix_packages(
         db=db,
-        conda_prefix=current_prefix,
+        conda_prefix=conda_prefix,
         build_id=build_id,
     )
 
@@ -193,7 +192,7 @@ def test_add_conda_prefix_packages(
 
 
 def test_add_lockfile_packages(
-    db, conda_store, simple_specification, simple_conda_lock, current_prefix
+    db, conda_store, simple_specification, simple_conda_lock
 ):
     task, solve_id = conda_store.register_solve(db, specification=simple_specification)
 


### PR DESCRIPTION
Previously they used the current conda prefix, but this is dangerous (there's a risk a broken test could break the dev environment), and the current conda prefix could contain things that break the tests.

This currently works by parameterizing in the fixture itself (currently just for two basic envs, one without pip packages and one with). But in the future we can do this parameterization on a per-test level with indirect parameterization. See
https://docs.pytest.org/en/latest/example/parametrize.html#indirect-parametrization

Currently, the test_generate_conda_export() test fails here. The reason is that it creates an export which cannot actually be read by the CondaSpecification object.

The reason for this is that the "name" of the environment that gets generated is just the same as the "prefix". This fails a validation check, because the name is guarded by a regular expression that disallows paths.

However, this appears to be a bug in conda-store, or maybe even an architectural issue. The "name" of a conda environment, as defined by "conda env export" at least, is only really defined if that environment is in the envs directory. I checked, and even env export yamls generated by conda-store itself (in standalone mode) end up having the prefix for the name, rather than the supposed actual environment name.

At best, it means that this test is just wrong and it shouldn't actually check the generated YAML file by trying to load it into a CondaSpecification.

I don't know if conda actually stores the environment "name" anywhere in the environment. It seems to me that this data should be stored separately by conda-store, especially since the environment path for environments created by conda-store is not actually the same as the environment name (the path contains a hash).

This is related to issue https://github.com/conda-incubator/conda-store/issues/513.

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed descrition for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description
<!-- What is the purpose of this pull request? -->

This pull request:

- a
- b
- c

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentaion (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
