### PR TITLE
Prevent traitlets from picking sys.argv during tests

### DIFF
--- a/conda-store-server/conda_store_server/worker/app.py
+++ b/conda-store-server/conda_store_server/worker/app.py
@@ -60,7 +60,7 @@ class CondaStoreWorker(Application):
 
     @catch_config_error
     def initialize(self, *args, **kwargs):
-        super().initialize(*args, **kwargs)
+        super().initialize(*args, **kwargs, argv=[])
         self.load_config_file(self.config_file)
 
         self.conda_store = CondaStore(parent=self, log=self.log)

--- a/conda-store-server/conda_store_server/worker/app.py
+++ b/conda-store-server/conda_store_server/worker/app.py
@@ -60,8 +60,6 @@ class CondaStoreWorker(Application):
 
     @catch_config_error
     def initialize(self, *args, **kwargs):
-        if "argv" not in kwargs:
-            kwargs["argv"] = []
         super().initialize(*args, **kwargs)
         self.load_config_file(self.config_file)
 

--- a/conda-store-server/conda_store_server/worker/app.py
+++ b/conda-store-server/conda_store_server/worker/app.py
@@ -60,7 +60,9 @@ class CondaStoreWorker(Application):
 
     @catch_config_error
     def initialize(self, *args, **kwargs):
-        super().initialize(*args, **kwargs, argv=[])
+        if 'argv' not in kwargs:
+            kwargs['argv'] = []
+        super().initialize(*args, **kwargs)
         self.load_config_file(self.config_file)
 
         self.conda_store = CondaStore(parent=self, log=self.log)

--- a/conda-store-server/conda_store_server/worker/app.py
+++ b/conda-store-server/conda_store_server/worker/app.py
@@ -60,8 +60,8 @@ class CondaStoreWorker(Application):
 
     @catch_config_error
     def initialize(self, *args, **kwargs):
-        if 'argv' not in kwargs:
-            kwargs['argv'] = []
+        if "argv" not in kwargs:
+            kwargs["argv"] = []
         super().initialize(*args, **kwargs)
         self.load_config_file(self.config_file)
 

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pathlib
 import datetime
 
@@ -18,7 +19,7 @@ def celery_config(conda_store):
 
 
 @pytest.fixture
-def conda_store_config(tmp_path):
+def conda_store_config(tmp_path, request):
     from traitlets.config import Config
 
     filename = pathlib.Path(tmp_path) / "database.sqlite"
@@ -29,6 +30,14 @@ def conda_store_config(tmp_path):
                 database_url=f"sqlite:///{filename}?check_same_thread=False"
             )
         )
+
+    original_sys_argv = list(sys.argv)
+    sys.argv = [sys.argv[0]]
+
+    def teardown():
+        sys.argv = list(original_sys_argv)
+
+    request.addfinalizer(teardown)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #538.
<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description
<!-- What is the purpose of this pull request? -->

This pull request:

- Prevents traitlets from picking `sys.argv`
- Fixes pytest issues

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

With this addition now you can call pytest flags in whatever order you want,

```
pytest tests/test_app_api.py -x -v
```

![image](https://github.com/conda-incubator/conda-store/assets/20992645/6f3c9392-5d0a-4deb-8817-0a8b24308642)

