### PR TITLE
Make conda-store-server test port configurable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,11 @@ import pytest
 from requests import Session
 from urllib.parse import urljoin
 
-
+CONDA_STORE_SERVER_PORT = os.environ.get(
+    "CONDA_STORE_SERVER_PORT", f"5000"
+)
 CONDA_STORE_BASE_URL = os.environ.get(
-    "CONDA_STORE_BASE_URL", "http://localhost:5000/conda-store/"
+    "CONDA_STORE_BASE_URL", f"http://localhost:{CONDA_STORE_SERVER_PORT}/conda-store/"
 )
 CONDA_STORE_USERNAME = os.environ.get("CONDA_STORE_USERNAME", "username")
 CONDA_STORE_PASSWORD = os.environ.get("CONDA_STORE_PASSWORD", "password")
@@ -45,3 +47,7 @@ class CondaStoreSession(Session):
 def testclient():
     session = CondaStoreSession(CONDA_STORE_BASE_URL)
     yield session
+
+@pytest.fixture
+def server_port():
+    return CONDA_STORE_SERVER_PORT

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -5,14 +5,14 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.playwright
-def test_integration(page: Page):
-    # Go to http://localhost:5000/conda-store/admin/
-    page.goto("http://localhost:5000/conda-store/admin/", wait_until="domcontentloaded")
+def test_integration(page: Page, server_port):
+    # Go to http://localhost:{server_port}/conda-store/admin/
+    page.goto(f"http://localhost:{server_port}/conda-store/admin/", wait_until="domcontentloaded")
     page.screenshot(path="test-results/conda-store-unauthenticated.png")
 
     # Click text=Login
     page.locator("text=Login").click()
-    # expect(page).to_have_url("http://localhost:5000/conda-store/login/")
+    # expect(page).to_have_url(f"http://localhost:{server_port}/conda-store/login/")
 
     # Click [placeholder="Username"]
     page.locator('[placeholder="Username"]').click()
@@ -27,7 +27,7 @@ def test_integration(page: Page):
     page.locator('[placeholder="Password"]').fill("password")
 
     # Click button:has-text("Sign In")
-    # with page.expect_navigation(url="http://localhost:5000/conda-store/"):
+    # with page.expect_navigation(url=f"http://localhost:{server_port}/conda-store/"):
     with page.expect_navigation():
         page.locator('button:has-text("Sign In")').click()
 
@@ -41,11 +41,11 @@ def test_integration(page: Page):
 
     # Press Enter
     page.locator('[placeholder="Search"]').press("Enter")
-    # expect(page).to_have_url("http://localhost:5000/conda-store/?search=python")
+    # expect(page).to_have_url(f"http://localhost:{server_port}/conda-store/?search=python")
 
     # Click text=filesystem/python-flask-env
     page.locator("text=filesystem / python-flask-env").click()
-    # expect(page).to_have_url("http://localhost:5000/conda-store/environment/filesystem/python-flask-env/")
+    # expect(page).to_have_url(f"http://localhost:{server_port}/conda-store/environment/filesystem/python-flask-env/")
 
     page.locator("a", has_text="Build").click()
 
@@ -61,7 +61,7 @@ def test_integration(page: Page):
 
     page.screenshot(path="test-results/conda-store-build-complete.png")
 
-    page.goto("http://localhost:5000/conda-store/admin/")
+    page.goto(f"http://localhost:{server_port}/conda-store/admin/")
 
-    page.goto("http://localhost:5000/conda-store/")
+    page.goto(f"http://localhost:{server_port}/conda-store/")
     time.sleep(5)


### PR DESCRIPTION
Related to https://github.com/conda-incubator/conda-store/issues/570 
<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->
I have to use a non-default port (not 5000) on my mac for development. This PR allows the playwright tests to run on any port instead of hard-coding the port. 

## Description
<!-- What is the purpose of this pull request? -->

This pull request:
- allows the playwright tests to run on a configurable port via env var
- creates a pytest fixture for the port
- updates the playwright test to use the new fixture

## Pull request checklist
<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information
<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
