### PR TITLE
update conda store dockerfile to have prod target

### DIFF
--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -69,6 +69,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: "${{ matrix.docker-image }}"
+          target: "prod"
           file: "${{ matrix.docker-image }}/Dockerfile"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "dcmcand-update-conda-store-dockerfile"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -1,11 +1,9 @@
-name: "Publish Docker Images"
+name: "Publish Dev Docker Images"
 
 on:
   push:
     branches:
       - "main"
-  release:
-    types: [created]
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -55,21 +53,20 @@ jobs:
 
       - name: "Add Docker metadata 📝"
         id: meta
-        uses: crazy-max/ghaction-docker-meta@v5
+        uses: docker/metadata-action@v5
         with:
           images: |
             quansight/${{ matrix.docker-image }}
             quay.io/quansight/${{ matrix.docker-image }}
           tags: |
             type=ref,event=tag
-            type=ref,event=branch
             type=sha
 
       - name: "Publish Docker image 🚀"
         uses: docker/build-push-action@v5
         with:
           context: "${{ matrix.docker-image }}"
-          target: "prod"
+          target: "dev"
           file: "${{ matrix.docker-image }}/Dockerfile"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "dcmcand-update-conda-store-dockerfile"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,11 +8,12 @@ on:
       - "*"
   workflow_dispatch:
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
 env:
   FORCE_COLOR: "1" # Make tools pretty.
-
-permissions:
-  contents: read # This is required for actions/checkout
 
 jobs:
   pypi-release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,12 +8,11 @@ on:
       - "*"
   workflow_dispatch:
 
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
-
 env:
   FORCE_COLOR: "1" # Make tools pretty.
+
+permissions:
+  contents: read # This is required for actions/checkout
 
 jobs:
   pypi-release:
@@ -55,6 +54,8 @@ jobs:
   build_and_push_docker_image:
     name: "Build Docker Images 🛠"
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     strategy:
       matrix:
         docker-image:
@@ -119,3 +120,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,4 +118,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,3 +50,72 @@ jobs:
         with:
           print-hash: true
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
+
+  build_and_push_docker_image:
+    name: "Build Docker Images 🛠"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker-image:
+          - conda-store
+          - conda-store-server
+    steps:
+      - name: "Checkout Repository 🛎"
+        uses: actions/checkout@v4
+
+      - name: "Retrieve secret from Vault 🗝"
+        uses: hashicorp/vault-action@v2
+        with:
+          method: jwt
+          url: "https://quansight-vault-public-vault-b2379fa7.d415e30e.z1.hashicorp.cloud:8200"
+          namespace: "admin/quansight"
+          role: "repository-conda-incubator-conda-store-role"
+          secrets: |
+            kv/data/repository/conda-incubator/conda-store/shared_secrets DOCKER_QUANSIGHT_USERNAME | DOCKER_USERNAME;
+            kv/data/repository/conda-incubator/conda-store/shared_secrets DOCKER_QUANSIGHT_PASSWORD | DOCKER_PASSWORD;
+            kv/data/repository/conda-incubator/conda-store/shared_secrets QUAY_QUANSIGHT_USERNAME | QUAY_USERNAME;
+            kv/data/repository/conda-incubator/conda-store/shared_secrets QUAY_QUANSIGHT_PASSWORD | QUAY_PASSWORD;
+
+      - name: "Set up Docker Buildx 🏗"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Login to Docker Hub 🐳"
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: "Login to quay.io 🐳"
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ env.QUAY_USERNAME }}
+          password: ${{ env.QUAY_PASSWORD }}
+
+      - name: "Add Docker metadata 📝"
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            quansight/${{ matrix.docker-image }}
+            quay.io/quansight/${{ matrix.docker-image }}
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch
+            type=sha
+
+      - name: "Publish Docker image 🚀"
+        uses: docker/build-push-action@v5
+        with:
+          context: "${{ matrix.docker-image }}"
+          target: "prod"
+          file: "${{ matrix.docker-image }}/Dockerfile"
+          build-args: |
+            RELEASE_VERSION=${{github.ref_name}}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -212,7 +212,7 @@ jobs:
           file: "${{ matrix.docker-image }}/Dockerfile"
           tags: |
             ${{ steps.meta.outputs.tags }}
-          target: "prod"
+          target: "dev"
           push: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -212,6 +212,7 @@ jobs:
           file: "${{ matrix.docker-image }}/Dockerfile"
           tags: |
             ${{ steps.meta.outputs.tags }}
+          target: "prod"
           push: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Docker Meta
         id: meta
-        uses: crazy-max/ghaction-docker-meta@v5
+        uses: docker/metadata-action@v5
         with:
           images: |
             quansight/${{ matrix.docker-image }}

--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -59,6 +59,6 @@ WORKDIR /var/lib/conda-store
 FROM base as prod
 ARG RELEASE_VERSION
 RUN cd /opt/conda-store-server && \
-    /opt/conda/envs/conda-store-server/bin/pip install conda-store-server==${RELEASE_VERSION} 
+    /opt/conda/envs/conda-store-server/bin/pip install conda-store-server==${RELEASE_VERSION}
 
 WORKDIR /var/lib/conda-store

--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -1,6 +1,9 @@
-FROM --platform=linux/amd64 condaforge/mambaforge:23.3.1-1 as prod
+FROM --platform=linux/amd64 condaforge/mambaforge:23.3.1-1 as base
 
 LABEL org.opencontainers.image.authors="conda-store development team"
+
+ENV PATH=/opt/conda/condabin:/opt/conda/envs/conda-store-server/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}
+ENV TZ=America/New_York
 
 RUN apt-get update && \
     # https://docs.anaconda.org/anaconda/install/linux/#installing-on-linux
@@ -46,11 +49,16 @@ USER 0:0
 RUN chown -R 1000:1000 /opt/conda-store-server/
 USER 1000:1000
 
-RUN ls -la /opt/conda-store-server/ && \
-    cd /opt/conda-store-server && \
-    /opt/conda/envs/conda-store-server/bin/pip install .
+FROM base as dev
 
-ENV PATH=/opt/conda/condabin:/opt/conda/envs/conda-store-server/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}
-ENV TZ=America/New_York
+RUN cd /opt/conda-store-server && \
+    /opt/conda/envs/conda-store-server/bin/pip install -e .
+
+WORKDIR /var/lib/conda-store
+
+FROM base as prod
+ARG RELEASE_VERSION
+RUN cd /opt/conda-store-server && \
+    /opt/conda/envs/conda-store-server/bin/pip install conda-store-server==${RELEASE_VERSION} 
 
 WORKDIR /var/lib/conda-store

--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -49,16 +49,16 @@ USER 0:0
 RUN chown -R 1000:1000 /opt/conda-store-server/
 USER 1000:1000
 
-FROM base as dev
-
-RUN cd /opt/conda-store-server && \
-    /opt/conda/envs/conda-store-server/bin/pip install -e .
-
-WORKDIR /var/lib/conda-store
-
 FROM base as prod
 ARG RELEASE_VERSION
 RUN cd /opt/conda-store-server && \
     /opt/conda/envs/conda-store-server/bin/pip install conda-store-server==${RELEASE_VERSION}
+
+WORKDIR /var/lib/conda-store
+
+FROM base as dev
+
+RUN cd /opt/conda-store-server && \
+    /opt/conda/envs/conda-store-server/bin/pip install -e .
 
 WORKDIR /var/lib/conda-store

--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 condaforge/mambaforge:23.3.1-1
+FROM --platform=linux/amd64 condaforge/mambaforge:23.3.1-1 as prod
 
 LABEL org.opencontainers.image.authors="conda-store development team"
 

--- a/conda-store/Dockerfile
+++ b/conda-store/Dockerfile
@@ -28,7 +28,8 @@ USER conda-store
 WORKDIR /opt/jupyterhub
 
 FROM base as prod
+ARG RELEASE_VERSION
 RUN cd /opt/conda-store && \
-    pip install .
+    pip install conda-store==${RELEASE_VERSION} 
 USER conda-store
 WORKDIR /opt/jupyterhub

--- a/conda-store/Dockerfile
+++ b/conda-store/Dockerfile
@@ -21,15 +21,15 @@ ENV PATH=/opt/conda/condabin:/opt/conda/envs/conda-store/bin:/opt/conda/bin:/usr
 
 COPY ./ /opt/conda-store/
 
-FROM base as dev
-RUN cd /opt/conda-store && \
-    pip install -e .
-USER conda-store
-WORKDIR /opt/jupyterhub
-
 FROM base as prod
 ARG RELEASE_VERSION
 RUN cd /opt/conda-store && \
     pip install conda-store==${RELEASE_VERSION}
+USER conda-store
+WORKDIR /opt/jupyterhub
+
+FROM base as dev
+RUN cd /opt/conda-store && \
+    pip install -e .
 USER conda-store
 WORKDIR /opt/jupyterhub

--- a/conda-store/Dockerfile
+++ b/conda-store/Dockerfile
@@ -30,6 +30,6 @@ WORKDIR /opt/jupyterhub
 FROM base as prod
 ARG RELEASE_VERSION
 RUN cd /opt/conda-store && \
-    pip install conda-store==${RELEASE_VERSION} 
+    pip install conda-store==${RELEASE_VERSION}
 USER conda-store
 WORKDIR /opt/jupyterhub

--- a/conda-store/Dockerfile
+++ b/conda-store/Dockerfile
@@ -1,15 +1,17 @@
-FROM --platform=linux/amd64 condaforge/mambaforge:23.3.1-1
+FROM --platform=linux/amd64 condaforge/mambaforge:23.3.1-1 as base
 
 LABEL org.opencontainers.image.authors="conda-store development team"
-
-USER root
 
 RUN apt-get update &&  \
     apt-get install -yq --no-install-recommends curl && \
     apt-get clean && \
     rm -rf /var/cache/apt/* &&\
     rm -rf /var/lib/apt/lists/* &&\
-    rm -rf /tmp/*
+    rm -rf /tmp/*   &&\
+    groupadd -g 1000 conda-store &&\
+    useradd -M -r -s /usr/sbin/nologin -u 1000 -g 1000  conda-store && \
+    mkdir -p /opt/jupyterhub && \
+    chown -R conda-store:conda-store /opt/jupyterhub
 
 COPY environment.yaml /opt/conda-store/environment.yaml
 
@@ -19,12 +21,14 @@ ENV PATH=/opt/conda/condabin:/opt/conda/envs/conda-store/bin:/opt/conda/bin:/usr
 
 COPY ./ /opt/conda-store/
 
+FROM base as dev
 RUN cd /opt/conda-store && \
     pip install -e .
+USER conda-store
+WORKDIR /opt/jupyterhub
 
-RUN mkdir -p /opt/jupyterhub && \
-    chown -R 1000:1000 /opt/jupyterhub
-
-USER 1000:1000
-
+FROM base as prod
+RUN cd /opt/conda-store && \
+    pip install .
+USER conda-store
 WORKDIR /opt/jupyterhub

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   conda-store-worker:
-    build: 
+    build:
       context: conda-store-server
       target: dev
     user: 1000:1000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,9 @@ version: "3.8"
 
 services:
   conda-store-worker:
-    build: conda-store-server
+    build: 
+      context: conda-store-server
+      target: dev
     user: 1000:1000
     volumes:
       - ./tests/assets/environments:/opt/environments:ro
@@ -19,7 +21,9 @@ services:
       ]
 
   conda-store-server:
-    build: conda-store-server
+    build:
+      context: conda-store-server
+      target: dev
     user: 1000:1000
     depends_on:
       postgres:

--- a/examples/docker-without-nfs/docker-compose.yaml
+++ b/examples/docker-without-nfs/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   conda-store-worker:
-    build: ../../conda-store-server
+    image: quansight/conda-store-server
     user: 1000:1000
     volumes:
       - conda_store_data:/opt/conda-store/
@@ -48,7 +48,7 @@ services:
       ]
 
   conda-store-server:
-    build: ../../conda-store-server
+    image: quansight/conda-store-server
     user: 1000:1000
     labels:
       - "traefik.enable=true"
@@ -81,7 +81,7 @@ services:
       - "5000:5000"
 
   jupyterhub:
-    build: ../../conda-store
+    build: quansight/conda-store
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.jupyterhub.rule=Host(`conda-store.localhost`) && (Path(`/`) || PathPrefix(`/hub`) || PathPrefix(`/user`))"

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       - conda_store_data:/opt/conda-store/
 
   conda-store-worker:
-    build: ../../conda-store-server
+    image: quansight/conda-store-server
     user: 1000:1000
     volumes:
       - conda_store_data:/opt/conda-store/
@@ -55,7 +55,7 @@ services:
     command: ['conda-store-worker', '--config', '/etc/conda-store/conda_store_config.py']
 
   conda-store-server:
-    build: ../../conda-store-server
+    image: quansight/conda-store-server
     user: 1000:1000
     labels:
       - "traefik.enable=true"
@@ -81,19 +81,8 @@ services:
     ports:
       - "5000:5000"
 
-  redis:
-    image: redis:6.2-alpine
-    restart: always
-    ports:
-      - '6379:6379'
-    command: redis-server --save 20 1 --loglevel debug
-    healthcheck:
-      test: ["CMD", "redis-cli","ping"]
-    volumes:
-      - redis:/etc/redis
-
   jupyterhub:
-    build: ../../conda-store
+    image: quansight/conda-store
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.jupyterhub.rule=Host(`conda-store.localhost`) && (Path(`/`) || PathPrefix(`/hub`) || PathPrefix(`/user`))"


### PR DESCRIPTION
Fixes #614
Part of #599 

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

updates Dockerfile for conda-store to have a prod target that does not install pip dependencies in editable mode, and a dev target that does.

This pull request:

- Update Dockerfile as described above
- Set github actions to use prod targets

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [X] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

