### PR TITLE
replace port 5000 with port 8080

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,7 +93,7 @@ jobs:
 
           wait-for-it localhost:5432 # postgresql
           wait-for-it localhost:9000 # minio
-          wait-for-it localhost:5000 # conda-store-server
+          wait-for-it localhost:8080 # conda-store-server
 
       - name: "Run Playwright tests 🎭"
         run: |
@@ -155,7 +155,7 @@ jobs:
 
           wait-for-it localhost:5432 # postgresql
           wait-for-it localhost:9000 # minio
-          wait-for-it localhost:5000 # conda-store-server
+          wait-for-it localhost:8080 # conda-store-server
 
       - name: "Install conda-store for tests 📦"
         run: |
@@ -172,7 +172,7 @@ jobs:
 
       - name: "Test shebang"
         run: |
-          export CONDA_STORE_URL=http://localhost:5000/conda-store
+          export CONDA_STORE_URL=http://localhost:8080/conda-store
           export CONDA_STORE_AUTH=basic
           export CONDA_STORE_USERNAME=username
           export CONDA_STORE_PASSWORD=password

--- a/conda-store-server/conda_store_server/client.py
+++ b/conda-store-server/conda_store_server/client.py
@@ -1,15 +1,15 @@
 import requests
 
 
-def get_environments(host="localhost", port="5000"):
+def get_environments(host="localhost", port="8080"):
     return requests.get(f"http://{host}:{port}/api/v1/environment/").json()
 
 
-def get_environment_packages(name, host="localhost", port="5000"):
+def get_environment_packages(name, host="localhost", port="8080"):
     return requests.get(f"http://{host}:{port}/api/v1/environment/{name}").json()
 
 
-def post_specification(specification, host="localhost", port="5000"):
+def post_specification(specification, host="localhost", port="8080"):
     return requests.post(
         f"http://{host}:{port}/api/v1/specification/", json=specification
     ).json()

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -79,10 +79,10 @@ class CondaStoreServer(Application):
         "0.0.0.0", help="ip address or hostname for conda-store server", config=True
     )
 
-    port = Integer(5000, help="port for conda-store server", config=True)
+    port = Integer(8080, help="port for conda-store server", config=True)
 
     registry_external_url = Unicode(
-        "localhost:5000",
+        "localhost:8080",
         help='external hostname and port to access docker registry cannot contain "http://" or "https://"',
         config=True,
     )

--- a/conda-store/conda_store/cli.py
+++ b/conda-store/conda_store/cli.py
@@ -36,7 +36,7 @@ async def parse_build(conda_store_api: api.CondaStoreAPI, uri: str):
 @click.group()
 @click.option(
     "--conda-store-url",
-    default="http://localhost:5000",
+    default="http://localhost:8080",
     envvar="CONDA_STORE_URL",
     help="conda-store base url including prefix",
 )

--- a/conda-store/tests/authenticated-tests.sh
+++ b/conda-store/tests/authenticated-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export CONDA_STORE_URL=http://localhost:5000/conda-store
+export CONDA_STORE_URL=http://localhost:8080/conda-store
 export CONDA_STORE_AUTH=basic
 export CONDA_STORE_USERNAME=username
 export CONDA_STORE_PASSWORD=password

--- a/conda-store/tests/authenticated-token-tests.sh
+++ b/conda-store/tests/authenticated-token-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export CONDA_STORE_URL=http://localhost:5000/conda-store
+export CONDA_STORE_URL=http://localhost:8080/conda-store
 export CONDA_STORE_AUTH=basic
 export CONDA_STORE_USERNAME=username
 export CONDA_STORE_PASSWORD=password

--- a/conda-store/tests/unauthenticated-tests.sh
+++ b/conda-store/tests/unauthenticated-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export CONDA_STORE_URL=http://localhost:5000/conda-store
+export CONDA_STORE_URL=http://localhost:8080/conda-store
 export CONDA_STORE_AUTH=none
 
 conda-store --version

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - ./tests/assets/conda_store_config.py:/opt/conda_store/conda_store_config.py:ro
     healthcheck:
       test:
-        ["CMD", "curl", "--fail", "http://localhost:5000/conda-store/api/v1/"]
+        ["CMD", "curl", "--fail", "http://localhost:8080/conda-store/api/v1/"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -48,7 +48,7 @@ services:
         "/opt/conda_store/conda_store_config.py",
       ]
     ports:
-      - "5000:5000"
+      - "8080:8080"
 
   minio:
     image: minio/minio:RELEASE.2020-11-10T21-02-24Z

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -435,7 +435,7 @@ metrics endpoints. Default True.
 to. The default is all IP addresses `0.0.0.0`.
 
 `CondaStoreServer.port` is the port for conda-store server to
-use. Default is `5000`.
+use. Default is `8080`.
 
 `CondaStoreServer.registry_external_url` is the external hostname and
 port to access docker registry cannot contain `http://` or `https://`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,15 +33,9 @@ arm architectures. Otherwise this workflow has been shown to run and build on OS
 Notice the `architecture: amd64` whithin the docker-compose.yaml files.
 :::
 
-:::{warning}
-If you're developing on a Mac and run into issues that complain about `tcp 0.0.0.0:5000: bind: address already in use` you might need to deactivate the `Airplay Receiver` service from the `Sharing` section in Control Center.
-Have a look at this [discussion on Apple.com](https://developer.apple.com/forums/thread/682332)
-for more details.
-:::
-
 The following resources will be available:
 
-- conda-store web server running at [http://localhost:5000](http://localhost:5000)
+- conda-store web server running at [http://localhost:8080](http://localhost:8080)
 - [MinIO](https://min.io/) s3 running at [http://localhost:9000](http://localhost:9000) with username `admin` and password `password`
 - [PostgreSQL](https://www.postgresql.org/) running at [localhost:5432](http://localhost:5432) with username `admin` and password `password` database `conda-store`
 - [Redis](https://www.redis.com/) running at [localhost:6379](http://localhost:6379) with password `password`
@@ -79,7 +73,7 @@ subprocess of the web server. Run
 python -m conda_store_server.server --standalone
 ```
 
-Then visit [localhost:5000](http://localhost:5000/).
+Then visit [localhost:8080](http://localhost:8080/).
 
 ### Changes to API
 
@@ -148,12 +142,12 @@ docker.
 $ cd conda-store
 $ docker-compose down -v # ensure you've cleared state
 $ docker-compose up --build
-# wait until the conda-store-server is running check by visiting localhost:5000
+# wait until the conda-store-server is running check by visiting localhost:8080
 
 $ pip install -e .
 $ ./tests/unauthenticated-tests.sh
 $ ./tests/authenticated-tests.sh
-$ export CONDA_STORE_URL=http://localhost:5000/conda-store
+$ export CONDA_STORE_URL=http://localhost:8080/conda-store
 $ export CONDA_STORE_AUTH=basic
 $ export CONDA_STORE_USERNAME=username
 $ export CONDA_STORE_PASSWORD=password
@@ -191,7 +185,7 @@ docker.
 $ cd conda-store-server
 $ docker-compose down -v # ensure you've cleared state
 $ docker-compose up --build
-# wait until the conda-store-server is running check by visiting localhos:5000
+# wait until the conda-store-server is running check by visiting localhos:8080
 $ hatch env run -e dev playwright-test
 $ hatch env run -e dev integration-test
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ Once installed, start conda-store using :
 conda-store-server --standalone
 ```
 
-You can then access conda-store on port 5000 of the machine running it.
+You can then access conda-store on port 8080 of the machine running it.
 
 ## Kubernetes
 
@@ -56,10 +56,10 @@ If your installation worked you should be able to port forward the
 conda-store web server.
 
 ```shell
-kubectl port-forward service/conda-store-server 5000:5000
+kubectl port-forward service/conda-store-server 8080:8080
 ```
 
-Then visit via your web browser [http://localhost:5000](http://localhost:5000)
+Then visit via your web browser [http://localhost:8080](http://localhost:8080)
 
 For additional configuration options see the [administrative
 guide](./administration.md)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -83,7 +83,7 @@ ways to handle Conda environment. In addition this registry leverages
 builds docker images without docker allowing for advanced caching,
 reduced image sizes, and does not require elevated privileges. Click
 on the `docker` link this will copy a url to your clipboard. Note the
-beginning of the url for example `localhost:5000/`. This is required to tell
+beginning of the url for example `localhost:8080/`. This is required to tell
 docker where the docker registry is located. Otherwise by default it
 will try and user docker hub. Your url will likely be different.
 
@@ -103,7 +103,7 @@ docker run -it <docker-url> python
 #### General usage
 
 ```shell
-docker run -it localhost:5000/<namespace>/<environment-name>
+docker run -it localhost:8080/<namespace>/<environment-name>
 ```
 
 If you want to use a specific build (say one that was built in the
@@ -112,10 +112,10 @@ build that you want in the UI and copy its docker registry tag
 name. The tag name is a combination of `<specification-sha256>-<build
 date>-<build id>-<environment name>` that we will refer to as build
 key. An example would be
-`localhost:5000/filesystem/python-numpy-env:583dd55140491c6b4cfa46e36c203e10280fe7e180190aa28c13f6fc35702f8f-20210825-180211-244815-3-python-numpy-env`.
+`localhost:8080/filesystem/python-numpy-env:583dd55140491c6b4cfa46e36c203e10280fe7e180190aa28c13f6fc35702f8f-20210825-180211-244815-3-python-numpy-env`.
 
 ```shell
-docker run -it localhost:5000/<namespace>/<environment-name>:<build_key>
+docker run -it localhost:8080/<namespace>/<environment-name>:<build_key>
 ```
 
 #### On Demand Docker Image

--- a/examples/docker-without-nfs/assets/conda_store_config.py
+++ b/examples/docker-without-nfs/assets/conda_store_config.py
@@ -42,7 +42,7 @@ c.CondaStoreServer.enable_api = True
 c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"
-c.CondaStoreServer.port = 5000
+c.CondaStoreServer.port = 8080
 # This MUST start with `/`
 c.CondaStoreServer.url_prefix = "/conda-store"
 c.CondaStoreServer.behind_proxy = True

--- a/examples/docker-without-nfs/docker-compose.yaml
+++ b/examples/docker-without-nfs/docker-compose.yaml
@@ -54,7 +54,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.conda-store.rule=Host(`conda-store.localhost`) && PathPrefix(`/conda-store`)"
       - "traefik.http.routers.conda-store.entrypoints=websecure"
-      - "traefik.port=5000"
+      - "traefik.port=8080"
     depends_on:
       postgres:
         condition: service_healthy
@@ -66,7 +66,7 @@ services:
       - ./assets/conda_store_config.py:/etc/conda-store/conda_store_config.py:ro
     healthcheck:
       test:
-        ["CMD", "curl", "--fail", "http://localhost:5000/conda-store/api/v1/"]
+        ["CMD", "curl", "--fail", "http://localhost:8080/conda-store/api/v1/"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -78,7 +78,7 @@ services:
         "/etc/conda-store/conda_store_config.py",
       ]
     ports:
-      - "5000:5000"
+      - "8080:8080"
 
   jupyterhub:
     build: quansight/conda-store

--- a/examples/docker/assets/conda_store_config.py
+++ b/examples/docker/assets/conda_store_config.py
@@ -37,7 +37,7 @@ c.CondaStoreServer.enable_api = True
 c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"
-c.CondaStoreServer.port = 5000
+c.CondaStoreServer.port = 8080
 # This MUST start with `/`
 c.CondaStoreServer.url_prefix = "/conda-store"
 c.CondaStoreServer.behind_proxy = True

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.conda-store.rule=Host(`conda-store.localhost`) && (PathPrefix(`/conda-store`) || PathPrefix(`/v2`))"
       - "traefik.http.routers.conda-store.entrypoints=websecure"
-      - "traefik.port=5000"
+      - "traefik.port=8080"
     depends_on:
       postgres:
         condition: service_healthy
@@ -72,14 +72,14 @@ services:
     volumes:
       - ./assets/conda_store_config.py:/etc/conda-store/conda_store_config.py:ro
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:5000/conda-store/api/v1/"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/conda-store/api/v1/"]
       interval: 10s
       timeout: 5s
       retries: 5
     platform: linux/amd64
     command: ['conda-store-server', '--config', '/etc/conda-store/conda_store_config.py']
     ports:
-      - "5000:5000"
+      - "8080:8080"
 
   jupyterhub:
     image: quansight/conda-store

--- a/examples/kubernetes/conda-store-server.yaml
+++ b/examples/kubernetes/conda-store-server.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - name: "5000"
+    - name: "8080"
       nodePort: 30500
-      port: 5000
-      targetPort: 5000
+      port: 8080
+      targetPort: 8080
   selector:
     app: conda-store-server
 ---
@@ -34,7 +34,7 @@ spec:
             - "--config"
             - "/etc/conda-store/conda_store_config.py"
           ports:
-            - containerPort: 5000
+            - containerPort: 8080
           volumeMounts:
             - name: config
               mountPath: "/etc/conda-store/"

--- a/examples/kubernetes/conda-store-worker.yaml
+++ b/examples/kubernetes/conda-store-worker.yaml
@@ -33,7 +33,7 @@ spec:
             - "--config"
             - "/etc/conda-store/conda_store_config.py"
           ports:
-            - containerPort: 5000
+            - containerPort: 8080
           volumeMounts:
             - name: config
               mountPath: "/etc/conda-store/"

--- a/examples/kubernetes/files/conda_store_config.py
+++ b/examples/kubernetes/files/conda_store_config.py
@@ -32,7 +32,7 @@ c.CondaStoreServer.enable_api = True
 c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"
-c.CondaStoreServer.port = 5000
+c.CondaStoreServer.port = 8080
 # This MUST start with `/`
 c.CondaStoreServer.url_prefix = "/"
 

--- a/examples/standalone/docker-compose.yaml
+++ b/examples/standalone/docker-compose.yaml
@@ -22,11 +22,11 @@ services:
     volumes:
       - conda_store_data:/var/lib/conda-store/
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:5000/api/v1/"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v1/"]
       interval: 10s
       timeout: 5s
       retries: 5
     platform: linux/amd64
     command: ["conda-store-server", "--standalone"]
     ports:
-      - "5000:5000"
+      - "8080:8080"

--- a/examples/ubuntu2004/templates/conda_store_config.py.j2
+++ b/examples/ubuntu2004/templates/conda_store_config.py.j2
@@ -33,7 +33,7 @@ c.CondaStoreServer.enable_api = True
 c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"
-c.CondaStoreServer.port = 5000
+c.CondaStoreServer.port = 8080
 # This MUST start with `/`
 c.CondaStoreServer.url_prefix = "/"
 

--- a/tests/assets/conda_store_config.py
+++ b/tests/assets/conda_store_config.py
@@ -40,7 +40,7 @@ c.CondaStoreServer.enable_api = True
 c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"
-c.CondaStoreServer.port = 5000
+c.CondaStoreServer.port = 8080
 # This MUST start with `/`
 c.CondaStoreServer.url_prefix = "/conda-store"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from requests import Session
 
 CONDA_STORE_SERVER_PORT = os.environ.get(
-    "CONDA_STORE_SERVER_PORT", f"5000"
+    "CONDA_STORE_SERVER_PORT", f"8080"
 )
 CONDA_STORE_BASE_URL = os.environ.get(
     "CONDA_STORE_BASE_URL", f"http://localhost:{CONDA_STORE_SERVER_PORT}/conda-store/"


### PR DESCRIPTION
Fixes #618  .

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description
Replaces port 5000 with port 8080 as the default port to run on. Port 8080 is not a privileged port, but is an alternate port for HTTP. Port 5000 is in use on some Mac computers which causes conflicts.

<!-- What is the purpose of this pull request? -->

This pull request:

- Replaces port 5000 with port 8080 as default port.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [X] Did you update the documentation (if required)?
- [X] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
