### PR TITLE
Change `url_prefix` to `/conda-store`

### DIFF
--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -88,7 +88,7 @@ class CondaStoreServer(Application):
     )
 
     url_prefix = Unicode(
-        "/",
+        "/conda-store",
         help="the prefix URL (subdirectory) for the entire application; "
         "it MUST start with a forward slash - tip: "
         "use this to run conda-store within an existing website.",

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -53,6 +53,7 @@ def conda_store_config(tmp_path, request):
 
 @pytest.fixture
 def conda_store_server(conda_store_config):
+    server_app.CondaStoreServer.url_prefix = "/"
     _conda_store_server = server_app.CondaStoreServer(config=conda_store_config)
     _conda_store_server.initialize()
 


### PR DESCRIPTION
This is what conda-store-ui expects, which allows running conda-store-server in standalone mode without passing the config.

Fixes #646.