### PR TITLE
Place a bound on docker-py

### DIFF
--- a/conda-store-server/environment-dev.yaml
+++ b/conda-store-server/environment-dev.yaml
@@ -52,6 +52,7 @@ dependencies:
   - sphinx-copybutton
   - pydata-sphinx-theme
   - playwright
+  - docker-py<7  # for docker-compose
   - docker-compose
   - pip
 

--- a/conda-store-server/environment-macos-dev.yaml
+++ b/conda-store-server/environment-macos-dev.yaml
@@ -52,6 +52,7 @@ dependencies:
   - sphinx-copybutton
   - pydata-sphinx-theme
   - playwright
+  - docker-py<7  # for docker-compose
   - docker-compose
   - pip
 

--- a/conda-store-server/environment-windows-dev.yaml
+++ b/conda-store-server/environment-windows-dev.yaml
@@ -52,6 +52,7 @@ dependencies:
   - sphinx-copybutton
   - pydata-sphinx-theme
   - playwright
+  - docker-py<7  # for docker-compose
   - docker-compose
   - pip
 


### PR DESCRIPTION
A new version of docker-py was released and it now causes issues with docker-compose because the latter doesn't work with the new version. This PR adds a bound to make sure the versions are compatible.

New version that causes problems:
```
docker-py                             7.0.0  pyhd8ed1ab_0        conda-forge/noarch
```

Old version that works:
```
docker-py                             6.1.3  pyhd8ed1ab_0        conda-forge/noarch
```

This error was printed on CI during Tests / integration-test conda-store-server (pull_request):

```
Traceback (most recent call last):
  File "/usr/share/miniconda3/envs/test/bin/docker-compose", line 11, in <module>
    sys.exit(main())
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/compose/cli/main.py", line 81, in main
    command_func()
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/compose/cli/main.py", line 200, in perform_command
    project = project_from_options('.', options)
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/compose/cli/command.py", line 60, in project_from_options
    return get_project(
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/compose/cli/command.py", line 152, in get_project
    client = get_client(
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/compose/cli/docker_client.py", line 41, in get_client
    client = docker_client(
  File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/compose/cli/docker_client.py", line 124, in docker_client
    kwargs = kwargs_from_env(environment=environment, ssl_version=tls_version)
TypeError: kwargs_from_env() got an unexpected keyword argument 'ssl_version'
Error: Process completed with exit code 1.
```