### PR TITLE
Set channel priority to strict, print config info

### DIFF
--- a/conda-store-server/conda_store_server/action/generate_lockfile.py
+++ b/conda-store-server/conda_store_server/action/generate_lockfile.py
@@ -26,8 +26,10 @@ def action_solve_lockfile(
         json.dump(specification.dict(), f)
 
     def print_cmd(cmd):
-        print(f"Running command: {' '.join(cmd)}")
-        print(subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding="utf-8"))
+        context.log.info(f"Running command: {' '.join(cmd)}")
+        context.log.info(
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding="utf-8")
+        )
 
     # The info command can be used with either mamba or conda
     print_cmd([conda_command, "info"])

--- a/conda-store-server/conda_store_server/action/generate_lockfile.py
+++ b/conda-store-server/conda_store_server/action/generate_lockfile.py
@@ -1,5 +1,7 @@
 import json
+import os
 import pathlib
+import subprocess
 import typing
 
 import yaml
@@ -13,6 +15,8 @@ def action_solve_lockfile(
     conda_command: str,
     specification: schema.CondaSpecification,
     platforms: typing.List[str] = [conda_utils.conda_platform()],
+    # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html
+    conda_flags: str = "--strict-channel-priority",
 ):
     environment_filename = pathlib.Path.cwd() / "environment.yaml"
     lockfile_filename = pathlib.Path.cwd() / "conda-lock.yaml"
@@ -20,12 +24,30 @@ def action_solve_lockfile(
     with environment_filename.open("w") as f:
         json.dump(specification.dict(), f)
 
-    run_lock(
-        environment_files=[environment_filename],
-        platforms=platforms,
-        lockfile_path=lockfile_filename,
-        conda_exe=conda_command,
-    )
+    def print_cmd(cmd):
+        print(f"Running command: {' '.join(cmd)}")
+        print(subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding="utf-8"))
+
+    # The info command can be used with either mamba or conda
+    print_cmd([conda_command, "info"])
+    # The config command is not supported by mamba
+    print_cmd(["conda", "config", "--show"])
+    print_cmd(["conda", "config", "--show-sources"])
+
+    # CONDA_FLAGS is used by conda-lock in conda_solver.solve_specs_for_arch
+    try:
+        conda_flags_name = "CONDA_FLAGS"
+        print(f"{conda_flags_name}={conda_flags}")
+        os.environ[conda_flags_name] = conda_flags
+
+        run_lock(
+            environment_files=[environment_filename],
+            platforms=platforms,
+            lockfile_path=lockfile_filename,
+            conda_exe=conda_command,
+        )
+    finally:
+        os.environ.pop(conda_flags_name, None)
 
     with lockfile_filename.open() as f:
         return yaml.safe_load(f)

--- a/conda-store-server/conda_store_server/action/generate_lockfile.py
+++ b/conda-store-server/conda_store_server/action/generate_lockfile.py
@@ -15,6 +15,7 @@ def action_solve_lockfile(
     conda_command: str,
     specification: schema.CondaSpecification,
     platforms: typing.List[str] = [conda_utils.conda_platform()],
+    # Avoids package compatibility issues, see:
     # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html
     conda_flags: str = "--strict-channel-priority",
 ):

--- a/conda-store-server/tests/test_actions.py
+++ b/conda-store-server/tests/test_actions.py
@@ -69,6 +69,29 @@ def test_solve_lockfile(conda_store, specification, request):
     assert len(context.result["package"]) != 0
 
 
+def test_solve_lockfile_valid_conda_flags(conda_store, simple_specification):
+    context = action.action_solve_lockfile(
+        conda_command=conda_store.conda_command,
+        specification=simple_specification,
+        platforms=[conda_utils.conda_platform()],
+        conda_flags="--strict-channel-priority",
+    )
+    assert len(context.result["package"]) != 0
+
+
+# Checks that conda_flags is used by conda-lock
+def test_solve_lockfile_invalid_conda_flags(conda_store, simple_specification):
+    with pytest.raises(Exception, match=(
+        r"Command.*--this-is-invalid.*returned non-zero exit status"
+    )):
+        action.action_solve_lockfile(
+            conda_command=conda_store.conda_command,
+            specification=simple_specification,
+            platforms=[conda_utils.conda_platform()],
+            conda_flags="--this-is-invalid",
+        )
+
+
 @pytest.mark.parametrize(
     "specification",
     [


### PR DESCRIPTION
This PR sets the channel priority to strict to avoid issues during solves when  multiple channels that were not specified are being used. This is done by passing the command line option `--strict-channel-priority` via the environment variable `CONDA_FLAGS`, which is used by conda-lock, which is a library conda-store uses to solve dependencies.

`CONDA_FLAGS` is used because it's a method of passing options that's local to conda-lock as opposed to editing global conda configuration files. Editing user configuration files may lead to unexpected issues in contexts where conda-store is used in standalone mode. Those configuration files affect how conda works outside of conda-store, which might be important to end users.

From the documentation at https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html:
> With strict channel priority, packages in lower priority channels are not considered if a package with the same name
appears in a higher priority channel.

Additionally, this PR adds code that prints useful system information related to conda configuration before the package solving process. This is useful for debugging. The commands used are:

- `conda/mamba info`, depending on the value of `conda_store.conda_command`
- `conda config --show`
- `conda config --show-sources`.

Note that the latter two commands are not supported by mamba, which is why conda is used.

Fixes #359, fixes #659.