### PR TITLE
Check if worker is initialized

### DIFF
--- a/conda-store-server/conda_store_server/alembic/versions/0f7e23ff24ee_add_worker.py
+++ b/conda-store-server/conda_store_server/alembic/versions/0f7e23ff24ee_add_worker.py
@@ -1,0 +1,29 @@
+"""add worker
+
+Revision ID: 0f7e23ff24ee
+Revises: 771180018e1b
+Create Date: 2023-12-13 21:01:45.546591
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0f7e23ff24ee"
+down_revision = "771180018e1b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "worker",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("initialized", sa.Boolean(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("initialized", name="_uc"),
+    )
+
+
+def downgrade():
+    op.drop_table("worker")

--- a/conda-store-server/conda_store_server/alembic/versions/0f7e23ff24ee_add_worker.py
+++ b/conda-store-server/conda_store_server/alembic/versions/0f7e23ff24ee_add_worker.py
@@ -21,7 +21,6 @@ def upgrade():
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("initialized", sa.Boolean(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("initialized", name="_uc_worker"),
     )
 
 

--- a/conda-store-server/conda_store_server/alembic/versions/0f7e23ff24ee_add_worker.py
+++ b/conda-store-server/conda_store_server/alembic/versions/0f7e23ff24ee_add_worker.py
@@ -21,7 +21,7 @@ def upgrade():
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("initialized", sa.Boolean(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("initialized", name="_uc"),
+        sa.UniqueConstraint("initialized", name="_uc_worker"),
     )
 
 

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -11,6 +11,7 @@ from conda_store_server.utils import BuildPathError
 from sqlalchemy import (
     JSON,
     BigInteger,
+    Boolean,
     Column,
     DateTime,
     Enum,
@@ -39,6 +40,22 @@ logger = logging.getLogger("orm")
 Base = declarative_base()
 
 ARN_ALLOWED_REGEX = re.compile(schema.ARN_ALLOWED)
+
+
+class Worker(Base):
+    """Used to communicate with the worker process"""
+
+    __tablename__ = "worker"
+
+    id = Column(Integer, primary_key=True)
+
+    # Used to check whether the worker is initialized
+    initialized = Column(Boolean, default=False)
+
+    __table_args__ = (
+        # Ensures no duplicates can be added with this combination of fields.
+        UniqueConstraint("initialized", name="_uc"),
+    )
 
 
 class Namespace(Base):

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -43,13 +43,13 @@ ARN_ALLOWED_REGEX = re.compile(schema.ARN_ALLOWED)
 
 
 class Worker(Base):
-    """Used to communicate with the worker process"""
+    """For communicating with the worker process"""
 
     __tablename__ = "worker"
 
     id = Column(Integer, primary_key=True)
 
-    # Used to check whether the worker is initialized
+    # For checking whether the worker is initialized
     initialized = Column(Boolean, default=False)
 
     __table_args__ = (

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -52,11 +52,6 @@ class Worker(Base):
     # For checking whether the worker is initialized
     initialized = Column(Boolean, default=False)
 
-    __table_args__ = (
-        # Ensures no duplicates can be added with this combination of fields.
-        UniqueConstraint("initialized", name="_uc_worker"),
-    )
-
 
 class Namespace(Base):
     """Namespace for resources"""

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -54,7 +54,7 @@ class Worker(Base):
 
     __table_args__ = (
         # Ensures no duplicates can be added with this combination of fields.
-        UniqueConstraint("initialized", name="_uc"),
+        UniqueConstraint("initialized", name="_uc_worker"),
     )
 
 

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -3,6 +3,7 @@ import os
 import posixpath
 import sys
 import time
+from enum import Enum
 from threading import Thread
 
 import conda_store_server
@@ -30,6 +31,12 @@ from traitlets import (
     validate,
 )
 from traitlets.config import Application, catch_config_error
+
+
+class _Color(str, Enum):
+    GREEN = "\x1b[32m"
+    RED = "\x1b[31m"
+    RESET = "\x1b[0m"
 
 
 class CondaStoreServer(Application):
@@ -346,11 +353,6 @@ class CondaStoreServer(Application):
         return app
 
     def _check_worker(self, delay=5):
-        # Uses colors to make the output more visible
-        green = "\x1b[32m"
-        red = "\x1b[31m"
-        reset = "\x1b[0m"
-
         # Creates a new DB connection since this will be run in a separate
         # thread and connections cannot be shared between threads
         session_factory = orm.new_session_factory(
@@ -364,15 +366,17 @@ class CondaStoreServer(Application):
             with session_factory() as db:
                 q = db.query(orm.Worker).first()
                 if q is not None and q.initialized:
-                    self.log.info(f"{green}" "Worker initialized" f"{reset}")
+                    self.log.info(
+                        f"{_Color.GREEN}" "Worker initialized" f"{_Color.RESET}"
+                    )
                     break
 
             time.sleep(delay)
             self.log.warning(
-                f"{red}"
+                f"{_Color.RED}"
                 "Waiting for worker... "
                 "Use --standalone if running outside of docker"
-                f"{reset}"
+                f"{_Color.RESET}"
             )
 
     def start(self):

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -28,9 +28,6 @@ from traitlets import (
 )
 from traitlets.config import Application, catch_config_error
 
-logger = logging.getLogger("app")
-logger.setLevel(logging.INFO)
-
 
 class CondaStoreServer(Application):
     aliases = {
@@ -394,11 +391,11 @@ class CondaStoreServer(Application):
                 with session_factory() as db:
                     q = db.query(orm.Worker).first()
                     if q is not None and q.initialized:
-                        logger.info(f"{green}" "Worker initialized" f"{reset}")
+                        self.log.info(f"{green}" "Worker initialized" f"{reset}")
                         break
 
                 time.sleep(5)
-                logger.critical(
+                self.log.warning(
                     f"{red}"
                     "Waiting for worker... "
                     "Use --standalone if running outside of docker"

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -387,7 +387,7 @@ class CondaStoreServer(Application):
             self.conda_store.ensure_namespace(db)
             self.conda_store.ensure_conda_channels(db)
 
-            # This ensures the database has no Worker table entires when the
+            # This ensures the database has no Worker table entries when the
             # server starts, which is necessary for the worker to signal that
             # it's ready via task_initialize_worker. Old Worker entries could
             # still be in the database on startup after they were added on the

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -2,11 +2,13 @@ import logging
 import os
 import posixpath
 import sys
+import time
+from threading import Thread
 
 import conda_store_server
 import conda_store_server.dbutil as dbutil
 import uvicorn
-from conda_store_server import __version__, storage
+from conda_store_server import __version__, orm, storage
 from conda_store_server.app import CondaStore
 from conda_store_server.server import auth, views
 from fastapi import FastAPI, HTTPException, Request
@@ -14,6 +16,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from sqlalchemy.pool import QueuePool
 from starlette.middleware.sessions import SessionMiddleware
 from traitlets import (
     Bool,
@@ -343,12 +346,6 @@ class CondaStoreServer(Application):
         return app
 
     def start(self):
-        import time
-        from threading import Thread
-
-        from conda_store_server import orm
-        from sqlalchemy.pool import QueuePool
-
         fastapi_app = self.init_fastapi_app()
 
         with self.conda_store.session_factory() as db:

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -60,8 +60,8 @@ class WorkerTask(Task):
         return self._worker
 
 
-# Signals to the server that the worker is running, see startup_event in
-# CondaStoreServer.init_fastapi_app
+# Signals to the server that the worker is running, see check_worker in
+# CondaStoreServer.start
 @shared_task(base=WorkerTask, name="task_initialize_worker", bind=True)
 def task_initialize_worker(self):
     from conda_store_server import orm

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -60,8 +60,8 @@ class WorkerTask(Task):
         return self._worker
 
 
-# Signals to the server that the worker is running, see check_worker in
-# CondaStoreServer.start
+# Signals to the server that the worker is running, see _check_worker in
+# CondaStoreServer
 @shared_task(base=WorkerTask, name="task_initialize_worker", bind=True)
 def task_initialize_worker(self):
     from conda_store_server import orm

--- a/conda-store-server/conda_store_server/worker/tasks.py
+++ b/conda-store-server/conda_store_server/worker/tasks.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session
 @worker_ready.connect
 def at_start(sender, **k):
     with sender.app.connection():
+        sender.app.send_task("task_initialize_worker")
         sender.app.send_task("task_update_conda_channels")
         sender.app.send_task("task_watch_paths")
         sender.app.send_task("task_cleanup_builds")
@@ -57,6 +58,19 @@ class WorkerTask(Task):
         platforms.signals["INT"] = _shutdown
 
         return self._worker
+
+
+# Signals to the server that the worker is running, see startup_event in
+# CondaStoreServer.init_fastapi_app
+@shared_task(base=WorkerTask, name="task_initialize_worker", bind=True)
+def task_initialize_worker(self):
+    from conda_store_server import orm
+
+    conda_store = self.worker.conda_store
+
+    with conda_store.session_factory() as db:
+        db.add(orm.Worker(initialized=True))
+        db.commit()
 
 
 @shared_task(base=WorkerTask, name="task_watch_paths", bind=True)


### PR DESCRIPTION
Fixes #605.

## Description

conda-store can run via docker and in standalone mode:
- in standalone mode, the `--standalone` CLI parameter must be used to start the worker sub-process
- when running via docker, this CLI parameter is not used because a dedicated worker process is started by docker-compose.

However, there might be cases where users forget to pass the `--standalone` parameter when running in standalone mode. This is a problem because the server cannot execute any tasks without the worker, so it must be running.

This PR adds a check that verifies whether the worker is running and prints an error message if not.

The worker is configured via a number of parameters, like `celery_broker_url`, which can either point to a database connection or use Redis:

```py
    @default("celery_broker_url")
    def _default_celery_broker_url(self):
        if self.redis_url is not None:
            return self.redis_url
        return f"sqla+{self.database_url}"
```

Similarly, checks like `conda_store.celery_app.control.inspect().ping()` won't work outside of Redis and RabbitMQ.

So we use a database entry to check whether the worker is initialized. The database is used because it will work regardless of parameters used to configure the worker.

Example output:
```
[CondaStoreServer] WARNING | Waiting for worker... Use --standalone if running outside of docker
[CondaStoreServer] WARNING | Waiting for worker... Use --standalone if running outside of docker
[CondaStoreServer] WARNING | Waiting for worker... Use --standalone if running outside of docker
[CondaStoreServer] Worker initialized
```

The warning message is printed in red, the info message is printed in green.

The simplest way to test this:
- run the server in one terminal, wait for warnings to be printed
- run the worker in another terminal, wait for the info message to be printed.

The commands to run from `conda-store/conda-store-server`:
```
terminal1: python -m conda_store_server.server
terminal2: python -m conda_store_server.worker
```

To test in standalone mode (also starts the worker):
```
python -m conda_store_server.server --standalone
```

To test via docker:
```
docker-compose build --build-arg RELEASE_VERSION=2023.10.1 && docker-compose up
```

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
