### PR TITLE
Log address and port, show exception trace from `uvicorn.run`

### DIFF
--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -365,6 +365,7 @@ class CondaStoreServer(Application):
             # Note: the logger needs to be defined here for the output to show
             # up, self.log doesn't work here either
             logger = logging.getLogger("app")
+            logger.addHandler(logging.StreamHandler())
             logger.setLevel(self.log_level)
             logger.info(f"Starting server on {self.address}:{self.port}")
 

--- a/conda-store-server/conda_store_server/server/app.py
+++ b/conda-store-server/conda_store_server/server/app.py
@@ -362,6 +362,12 @@ class CondaStoreServer(Application):
             process.start()
 
         try:
+            # Note: the logger needs to be defined here for the output to show
+            # up, self.log doesn't work here either
+            logger = logging.getLogger("app")
+            logger.setLevel(self.log_level)
+            logger.info(f"Starting server on {self.address}:{self.port}")
+
             uvicorn.run(
                 fastapi_app,
                 host=self.address,
@@ -376,6 +382,11 @@ class CondaStoreServer(Application):
                     else []
                 ),
             )
+        except:
+            import traceback
+
+            traceback.print_exc()
+            raise
         finally:
             if self.standalone:
                 process.join()


### PR DESCRIPTION
Fixes #562.

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

<!-- What is the purpose of this pull request? -->

This pull request:

- logs address and port on startup
- shows exception trace from `uvicorn.run`.

Example output when the port is already in use:

```
INFO  [app] Starting server on 0.0.0.0:8080
Traceback (most recent call last):
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/site-packages/uvicorn/server.py", line 160, in startup
    server = await loop.create_server(
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/asyncio/base_events.py", line 1493, in create_server
    raise OSError(err.errno, 'error while attempting '
OSError: [Errno 98] error while attempting to bind on address ('0.0.0.0', 8080): address already in use

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/test/conda-store/conda-store-server/conda_store_server/server/app.py", line 371, in start
    uvicorn.run(
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/site-packages/uvicorn/main.py", line 587, in run
    server.run()
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/site-packages/uvicorn/server.py", line 61, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/asyncio/base_events.py", line 628, in run_until_complete
    self.run_forever()
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/asyncio/base_events.py", line 595, in run_forever
    self._run_once()
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/asyncio/base_events.py", line 1881, in _run_once
    handle._run()
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/site-packages/uvicorn/server.py", line 78, in serve
    await self.startup(sockets=sockets)
  File "/home/test/miniconda3/envs/conda-store-server-dev/lib/python3.10/site-packages/uvicorn/server.py", line 170, in startup
    sys.exit(1)
SystemExit: 1
```


## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
