### PR TITLE
Use string substitution in `normalized_channel_url`

### DIFF
--- a/conda-store-server/conda_store_server/conda_utils.py
+++ b/conda-store-server/conda_store_server/conda_utils.py
@@ -132,7 +132,13 @@ def download_repodata(
             "https://repo.anaconda.com/pkgs/main"
         )
     }
-    normalized_channel_url = yarl.URL(channel) / "./"
+    # Note: this doesn't use the / operator to append the trailing / character
+    # because it's ignored on Windows. Instead, string substitution is used if
+    # the / character is not present
+    if channel.endswith("/"):
+        normalized_channel_url = yarl.URL(channel)
+    else:
+        normalized_channel_url = yarl.URL(f"{channel}/")
     channel_url = channel_replacements.get(
         str(normalized_channel_url), yarl.URL(channel)
     )

--- a/conda-store-server/conda_store_server/conda_utils.py
+++ b/conda-store-server/conda_store_server/conda_utils.py
@@ -109,6 +109,27 @@ def conda_lock(specification: "CondaSpecification", conda_exe: str = "mamba"):  
     return {"conda": conda_packages, "pip": pip_packages}
 
 
+def get_channel_url(channel: str) -> yarl.URL:
+    # the conda main channel does not have a channeldata.json within
+    # the https://conda.anaconda.org/<channel>/channeldata.json
+    # so we replace the given url with it's equivalent alias
+    channel_replacements = {
+        "https://conda.anaconda.org/main/": yarl.URL(
+            "https://repo.anaconda.com/pkgs/main"
+        )
+    }
+
+    # Note: this doesn't use the / operator to append the trailing / character
+    # because it's ignored on Windows. Instead, string substitution is used if
+    # the / character is not present
+    if channel.endswith("/"):
+        normalized_channel_url = yarl.URL(channel)
+    else:
+        normalized_channel_url = yarl.URL(f"{channel}/")
+
+    return channel_replacements.get(str(normalized_channel_url), yarl.URL(channel))
+
+
 def download_repodata(
     channel: str,
     last_update: datetime.datetime = None,
@@ -124,24 +145,7 @@ def download_repodata(
     """
     subdirs = set(subdirs or [conda_platform(), "noarch"])
 
-    # the conda main channel does not have a channeldata.json within
-    # the https://conda.anaconda.org/<channel>/channeldata.json
-    # so we replace the given url with it's equivalent alias
-    channel_replacements = {
-        "https://conda.anaconda.org/main/": yarl.URL(
-            "https://repo.anaconda.com/pkgs/main"
-        )
-    }
-    # Note: this doesn't use the / operator to append the trailing / character
-    # because it's ignored on Windows. Instead, string substitution is used if
-    # the / character is not present
-    if channel.endswith("/"):
-        normalized_channel_url = yarl.URL(channel)
-    else:
-        normalized_channel_url = yarl.URL(f"{channel}/")
-    channel_url = channel_replacements.get(
-        str(normalized_channel_url), yarl.URL(channel)
-    )
+    channel_url = get_channel_url(channel)
 
     headers = {}
     if last_update:

--- a/conda-store-server/tests/test_actions.py
+++ b/conda-store-server/tests/test_actions.py
@@ -5,6 +5,7 @@ import re
 import sys
 
 import pytest
+import yarl
 from conda_store_server import (
     BuildKey,
     action,
@@ -346,3 +347,13 @@ def test_api_get_build_lockfile(
         assert lockfile_url(build_key) == build.conda_lock_key
         assert lockfile_url(build_key) == res.headers['location']
         assert res.status_code == 307
+
+
+def test_get_channel_url():
+    conda_main = "https://conda.anaconda.org/main"
+    repo_main = "https://repo.anaconda.com/pkgs/main"
+    example = "https://example.com"
+
+    assert conda_utils.get_channel_url(conda_main) == yarl.URL(repo_main)
+    assert conda_utils.get_channel_url(f"{conda_main}/") == yarl.URL(repo_main)
+    assert conda_utils.get_channel_url(example) == yarl.URL(example)


### PR DESCRIPTION
Fixes #602.

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

<!-- What is the purpose of this pull request? -->

This pull request: appends the trailing slash to `normalized_channel_url` via string interpolation. The previous method of using the `/` operator was ignoring the trailing slash on Windows, which caused a `channel_replacements` lookup failure.

On Linux:

```
In [2]: yarl.URL("foo") / "./"
Out[2]: URL('foo/')
```

On Windows the slash is not appended, so the lookup in `channel_replacements` failed:

```
In [4]: yarl.URL("foo") / "./"
Out[4]: URL('foo')
```

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
