### PR TITLE
Add extended-length prefix support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,7 +62,20 @@ jobs:
 
       - name: "Unit tests ✅"
         run: |
-          pytest tests
+          pytest -m "not extended_prefix" tests
+
+      # https://github.com/actions/runner-images/issues/1052
+      - name: "Windows extended prefix unit tests ✅"
+        shell: pwsh
+        run: |
+          Set-ItemProperty "HKLM:\System\CurrentControlSet\Control\FileSystem" `
+            -Name "LongPathsEnabled" `
+            -Value 0 `
+            -Type DWord
+          (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
+          pytest -m "extended_prefix" tests
+        if: matrix.os == 'windows'
+
 
   integration-test-conda-store-server:
     name: "integration-test conda-store-server"

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -120,6 +120,12 @@ class CondaStore(LoggingConfigurable):
         except Exception as e:
             raise TraitError(f"c.CondaStore.build_key_version: {e}")
 
+    win_extended_length_prefix = Bool(
+        False,
+        help="Use the extended-length prefix '\\\\?\\' (Windows-only), default: False",
+        config=True,
+    )
+
     conda_command = Unicode(
         "mamba",
         help="conda executable to use for solves",

--- a/conda-store-server/conda_store_server/orm.py
+++ b/conda-store-server/conda_store_server/orm.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import re
 import shutil
+import sys
 
 from conda_store_server import conda_utils, schema, utils
 from conda_store_server.environment import validate_environment
@@ -254,7 +255,12 @@ class Build(Base):
         # https://github.com/conda-incubator/conda-store/issues/649
         if len(str(res)) > 255:
             raise BuildPathError("build_path too long: must be <= 255 characters")
-        return res
+        # Note: cannot use the '/' operator to prepend the extended-length
+        # prefix
+        if sys.platform == "win32" and conda_store.win_extended_length_prefix:
+            return pathlib.Path(f"\\\\?\\{res}")
+        else:
+            return res
 
     def environment_path(self, conda_store):
         """Environment path is the path for the symlink to the build
@@ -264,11 +270,17 @@ class Build(Base):
         store_directory = os.path.abspath(conda_store.store_directory)
         namespace = self.environment.namespace.name
         name = self.specification.name
-        return pathlib.Path(
+        res = pathlib.Path(
             conda_store.environment_directory.format(
                 store_directory=store_directory, namespace=namespace, name=name
             )
         )
+        # Note: cannot use the '/' operator to prepend the extended-length
+        # prefix
+        if sys.platform == "win32" and conda_store.win_extended_length_prefix:
+            return pathlib.Path(f"\\\\?\\{res}")
+        else:
+            return res
 
     @property
     def build_key(self):

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -449,7 +449,7 @@ def test_create_specification_auth_extended_prefix(win_extended_length_prefix, t
         r = schema.APIGetBuild.parse_obj(response.json())
         assert r.status == schema.APIStatus.OK
         assert r.data.specification.name == environment_name
-        if r.data.status in ["QUEUED", "BUILDING"]:
+        if r.data.status in ("QUEUED", "BUILDING"):
             continue  # checked too fast, try again
 
         if win_extended_length_prefix:
@@ -465,7 +465,7 @@ def test_create_specification_auth_extended_prefix(win_extended_length_prefix, t
 
     # If we're here, the task didn't update the status on failure
     if not is_updated:
-        assert False, f"failed to get status"
+        assert False, "failed to update status"
 
 
 def test_create_specification_auth(testclient, celery_worker, authenticate):

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -3,6 +3,7 @@ import sys
 import time
 
 import pytest
+import traitlets
 import yaml
 from conda_store_server import __version__, schema
 
@@ -400,9 +401,12 @@ def test_create_specification_auth_env_name_too_long(testclient, celery_worker, 
 @pytest.fixture
 def win_extended_length_prefix(request):
     # Overrides the attribute before other fixtures are called
-    import conda_store_server
-    conda_store_server.app.CondaStore.win_extended_length_prefix = request.param
+    from conda_store_server.app import CondaStore
+    assert type(CondaStore.win_extended_length_prefix) is traitlets.Bool
+    old_prefix = CondaStore.win_extended_length_prefix.default_value
+    CondaStore.win_extended_length_prefix.default_value = request.param
     yield request.param
+    CondaStore.win_extended_length_prefix.default_value = old_prefix
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="tests a Windows issue")

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import time
 
 import pytest
@@ -394,6 +395,77 @@ def test_create_specification_auth_env_name_too_long(testclient, celery_worker, 
     # If we're here, the task didn't update the status on failure
     if not is_updated:
         assert False, f"failed to update status"
+
+
+@pytest.fixture
+def win_extended_length_prefix(request):
+    # Overrides the attribute before other fixtures are called
+    import conda_store_server
+    conda_store_server.app.CondaStore.win_extended_length_prefix = request.param
+    yield request.param
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="tests a Windows issue")
+@pytest.mark.parametrize('win_extended_length_prefix', [True, False], indirect=True)
+@pytest.mark.extended_prefix
+def test_create_specification_auth_extended_prefix(win_extended_length_prefix, testclient, celery_worker, authenticate):
+    # Adds padding to cause an error if the extended prefix is not enabled
+    namespace = "default" + 'A' * 10
+    environment_name = "pytest"
+
+    # The debugpy 1.8.0 package was deliberately chosen because it has long
+    # paths internally, which causes issues on Windows due to the path length
+    # limit
+    response = testclient.post(
+        "api/v1/specification",
+        json={
+            "namespace": namespace,
+            "specification": json.dumps({
+                "name": environment_name,
+                "channels": ["conda-forge"],
+                "dependencies": ["debugpy==1.8.0"],
+                "variables": None,
+                "prefix": None,
+                "description": "test"
+            }),
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+
+    r = schema.APIPostSpecification.parse_obj(response.json())
+    assert r.status == schema.APIStatus.OK
+    build_id = r.data.build_id
+
+    # Try checking that the status is 'FAILED'
+    is_updated = False
+    for _ in range(30):
+        time.sleep(5)
+
+        # check for the given build
+        response = testclient.get(f"api/v1/build/{build_id}", timeout=30)
+        response.raise_for_status()
+
+        r = schema.APIGetBuild.parse_obj(response.json())
+        assert r.status == schema.APIStatus.OK
+        assert r.data.specification.name == environment_name
+        if r.data.status in ["QUEUED", "BUILDING"]:
+            continue  # checked too fast, try again
+
+        if win_extended_length_prefix:
+            assert r.data.status == "COMPLETED"
+        else:
+            assert r.data.status == "FAILED"
+            response = testclient.get(f"api/v1/build/{build_id}/logs", timeout=30)
+            response.raise_for_status()
+            assert "[WinError 206] The filename or extension is too long" in response.text
+
+        is_updated = True
+        break
+
+    # If we're here, the task didn't update the status on failure
+    if not is_updated:
+        assert False, f"failed to get status"
 
 
 def test_create_specification_auth(testclient, celery_worker, authenticate):

--- a/conda-store-server/tests/test_server.py
+++ b/conda-store-server/tests/test_server.py
@@ -403,10 +403,10 @@ def win_extended_length_prefix(request):
     # Overrides the attribute before other fixtures are called
     from conda_store_server.app import CondaStore
     assert type(CondaStore.win_extended_length_prefix) is traitlets.Bool
-    old_prefix = CondaStore.win_extended_length_prefix.default_value
-    CondaStore.win_extended_length_prefix.default_value = request.param
+    old_prefix = CondaStore.win_extended_length_prefix
+    CondaStore.win_extended_length_prefix = request.param
     yield request.param
-    CondaStore.win_extended_length_prefix.default_value = old_prefix
+    CondaStore.win_extended_length_prefix = old_prefix
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="tests a Windows issue")


### PR DESCRIPTION
Fixes #588.

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

<!-- What is the purpose of this pull request? -->

This pull request:

- adds support for the Windows [extended-length prefix](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation) (`"\\?\"`) via the `win_extended_length_prefix` option
- adds a test
- updates the docs.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
