### PR TITLE
Pass `CONDA_OVERRIDE_CUDA` to `with_cuda` of conda-lock

### DIFF
--- a/conda-store-server/conda_store_server/action/generate_lockfile.py
+++ b/conda-store-server/conda_store_server/action/generate_lockfile.py
@@ -37,6 +37,16 @@ def action_solve_lockfile(
     print_cmd(["conda", "config", "--show"])
     print_cmd(["conda", "config", "--show-sources"])
 
+    # conda-lock ignores variables defined in the specification, so this code
+    # gets the value of CONDA_OVERRIDE_CUDA and passes it to conda-lock via
+    # the with_cuda parameter, see:
+    # https://github.com/conda-incubator/conda-store/issues/719
+    # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html#overriding-detected-packages
+    if specification.variables is not None:
+        cuda_version = specification.variables.get("CONDA_OVERRIDE_CUDA")
+    else:
+        cuda_version = None
+
     # CONDA_FLAGS is used by conda-lock in conda_solver.solve_specs_for_arch
     try:
         conda_flags_name = "CONDA_FLAGS"
@@ -48,6 +58,7 @@ def action_solve_lockfile(
             platforms=platforms,
             lockfile_path=lockfile_filename,
             conda_exe=conda_command,
+            with_cuda=cuda_version,
         )
     finally:
         os.environ.pop(conda_flags_name, None)

--- a/conda-store-server/conda_store_server/action/generate_lockfile.py
+++ b/conda-store-server/conda_store_server/action/generate_lockfile.py
@@ -42,6 +42,8 @@ def action_solve_lockfile(
     # the with_cuda parameter, see:
     # https://github.com/conda-incubator/conda-store/issues/719
     # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html#overriding-detected-packages
+    # TODO: Support all variables once upstream fixes are made to conda-lock,
+    # see the discussion in issue 719.
     if specification.variables is not None:
         cuda_version = specification.variables.get("CONDA_OVERRIDE_CUDA")
     else:


### PR DESCRIPTION
Fixes #719.

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

<!-- What is the purpose of this pull request? -->

This pull request makes it possible to set the CUDA version by passing the value of the `CONDA_OVERRIDE_CUDA` specification variable to the `with_cuda` parameter of conda-lock.

See https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html#overriding-detected-packages

How I tested this:

- Created this test env _via the server admin environment page_ because _conda-store UI strips variables even in raw YAML mode_, so it doesn't work there:

```yaml
channels:
- conda-forge
dependencies:
- pytorch
- ipykernel
- pip:
  - nothing
description: test2
name: test3
prefix: null
variables:
  CONDA_OVERRIDE_CUDA: '12.0'
```

- Checked that the pytorch package in the generated lockfile has constraints matching this version of cuda. The url of the pytorch package should also reflect that, e.g., `https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.1.0-cuda120py312hfe5e8c6_301.conda`.

- Additionally, on a machine with an NVIDIA card that's configured to use CUDA:

```
% CONDA_STORE_USERNAME=test CONDA_STORE_PASSWORD=password  python -m conda_store --conda-store-url="http://localhost:8080/conda-store/" --auth=basic run test/test3:4 -- python
>>> import torch
>>> torch.__file__
'/tmp/conda-store/4/lib/python3.12/site-packages/torch/__init__.py'
>>> print(torch.version.cuda)
12.0
```

This version matches the one in the lockfile, which comes from the variable. Note: I had to set the url when calling conda-store CLI in order to match the url used by the server when running via docker.

- Repeated the same with versions `10.0` and `11.0`. Observed that these affect constraints in the pytorch package in the lockfile. Note that I've used different major versions as minor versions don't affect the constraints in the lockfile.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
