### PR TITLE
Add user journey for logging in and deleting shared environment

### DIFF
--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -56,7 +56,9 @@ def test_admin_login_and_delete_shared_environment(
     environment = api.create_environment(
         namespace,
         specification_path,
-    ).json()["data"]["specification"]["name"]
+    ).json()["data"][
+        "specification"
+    ]["name"]
 
     api.delete_environment(namespace, environment)
     api.delete_namespace(namespace)
@@ -83,14 +85,18 @@ def test_user_login_and_create_shared_environment(
         base_url=base_url,
         token=api.create_token(
             namespace,
-            'developer',
-        ).json()['data']['token']
+            "developer",
+        ).json()[
+            "data"
+        ]["token"],
     )
 
     environment = dev_api.create_environment(
         namespace,
         specification_path,
-    ).json()["data"]["specification"]["name"]
+    ).json()[
+        "data"
+    ]["specification"]["name"]
 
     api.delete_environment(namespace, environment)
     api.delete_namespace(namespace)

--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -47,10 +47,11 @@ def test_admin_user_can_create_environment(
 def test_admin_login_and_delete_shared_environment(
     base_url: str, specification_path: str
 ) -> None:
-    """Test that a user can login and delete an environment in a shared namespace."""
+    """Test that an admin can login and create/delete an env in a shared namespace."""
     api = utils.API(base_url=base_url)
 
-    # Create a shared namespace; default permissions for namepace/environment */* is admin
+    # Create a shared namespace; default permissions for namepace/environment
+    # */* is admin
     namespace = api.create_namespace().json()["data"]["name"]
     environment = api.create_environment(
         namespace,
@@ -68,19 +69,21 @@ def test_admin_login_and_delete_shared_environment(
         ("tests/user_journeys/test_data/simple_environment.yaml"),
     ],
 )
-def test_user_login_and_delete_shared_environment(
+def test_user_login_and_create_shared_environment(
     base_url: str, specification_path: str
 ) -> None:
-    """Test that a user can login and delete an environment in a shared namespace."""
+    """Test that a user can login and create an environment in a shared namespace."""
     api = utils.API(base_url=base_url)
-    # Create a shared namespace; default permissions for namepace/environment */* is admin
+
+    # Create a shared namespace; default permissions for namepace/environment
+    # */* is admin
     namespace = api.create_namespace().json()["data"]["name"]
 
     dev_api = utils.API(
         base_url=base_url,
         token=api.create_token(
             namespace,
-            'editor',
+            'developer',
         ).json()['data']['token']
     )
 
@@ -89,5 +92,5 @@ def test_user_login_and_delete_shared_environment(
         specification_path,
     ).json()["data"]["specification"]["name"]
 
-    dev_api.delete_environment(namespace, environment)
+    api.delete_environment(namespace, environment)
     api.delete_namespace(namespace)

--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -29,15 +29,65 @@ def test_admin_user_can_create_environment(
     base_url: str, token: str, specification_path: str
 ) -> None:
     """Test that an admin user can create an environment."""
-    namespace = utils.API.gen_random_namespace()
     api = utils.API(base_url=base_url, token=token)
-    api.create_namespace(namespace)
-    response = api.create_environment(namespace, specification_path)
-    data = response.json()["data"]
-    assert "build_id" in data
-    build_id = data["build_id"]
-    assert build_id is not None
-    build = api.wait_for_successful_build(build_id)
-    environment_name = build.json()["data"]["specification"]["name"]
-    api.delete_environment(namespace, environment_name)
+    namespace = "default"
+    environment = api.create_environment(namespace, specification_path).json()["data"][
+        "specification"
+    ]["name"]
+    api.delete_environment(namespace, environment)
+
+
+@pytest.mark.user_journey
+@pytest.mark.parametrize(
+    "specification_path",
+    [
+        ("tests/user_journeys/test_data/simple_environment.yaml"),
+    ],
+)
+def test_admin_login_and_delete_shared_environment(
+    base_url: str, specification_path: str
+) -> None:
+    """Test that a user can login and delete an environment in a shared namespace."""
+    api = utils.API(base_url=base_url)
+
+    # Create a shared namespace; default permissions for namepace/environment */* is admin
+    namespace = api.create_namespace().json()["data"]["name"]
+    environment = api.create_environment(
+        namespace,
+        specification_path,
+    ).json()["data"]["specification"]["name"]
+
+    api.delete_environment(namespace, environment)
+    api.delete_namespace(namespace)
+
+
+@pytest.mark.user_journey
+@pytest.mark.parametrize(
+    "specification_path",
+    [
+        ("tests/user_journeys/test_data/simple_environment.yaml"),
+    ],
+)
+def test_user_login_and_delete_shared_environment(
+    base_url: str, specification_path: str
+) -> None:
+    """Test that a user can login and delete an environment in a shared namespace."""
+    api = utils.API(base_url=base_url)
+    # Create a shared namespace; default permissions for namepace/environment */* is admin
+    namespace = api.create_namespace().json()["data"]["name"]
+
+    dev_api = utils.API(
+        base_url=base_url,
+        token=api.create_token(
+            namespace,
+            'editor',
+        ).json()['data']['token']
+    )
+
+    environment = dev_api.create_environment(
+        namespace,
+        specification_path,
+    ).json()["data"]["specification"]["name"]
+
+    dev_api.delete_environment(namespace, environment)
     api.delete_namespace(namespace)


### PR DESCRIPTION
Fixed https://github.com/conda-incubator/conda-store/issues/669.

## Description

This PR implements an integration test which checks that an admin can create an environment in a shared namespace and delete both the environment and the namespace.

This pull request:

- Adds an integration test which logs a user in and deletes an environment in a shared namespace and the namespace itself
- Modifies the existing `test_admin_user_can_create_environment` test; previously, that test was doing something very similar to what the new test implemented in this PR does. With this change, the existing test now tests that an admin can create an environment in the `default` namespace, more closely matching the existing docstring.
- This PR refactors the `user_journeys.utils.API` class to wait for responses from the conda-store server so that we don't need to do response handling in every test we write.


## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional information

- See the https://github.com/conda-incubator/conda-store/issues/662 meta-issue for additional context.

## How to test

1. Load the conda-store server with `docker compose up`
2. Run the test with `pytest conda-store-server/tests/user_journeys/test_user_journeys.py`

Alternatively, these tests are run as part of CI.