### PR TITLE
Make conda_flags configurable

### DIFF
--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -147,6 +147,12 @@ class CondaStore(LoggingConfigurable):
         config=True,
     )
 
+    conda_flags = Unicode(
+        "--strict-channel-priority",
+        help="The flags to be passed through the CONDA_FLAGS environment variable during the environment build",
+        config=True,
+    )
+
     conda_platforms = List(
         [conda_utils.conda_platform(), "noarch"],
         help="Conda platforms to download package repodata.json from. By default includes current architecture and noarch",

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -178,6 +178,7 @@ def build_conda_environment(db: Session, conda_store, build):
                     build.specification.spec
                 ),
                 platforms=settings.conda_solve_platforms,
+                conda_flags=conda_store.conda_flags,
             )
 
             conda_store.storage.set(
@@ -275,6 +276,7 @@ def solve_conda_environment(db: Session, conda_store, solve: orm.Solve):
         conda_command=settings.conda_command,
         specification=schema.CondaSpecification.parse_obj(solve.specification.spec),
         platforms=[conda_utils.conda_platform()],
+        conda_flags=conda_store.conda_flags,
     )
     conda_lock_spec = context.result
 


### PR DESCRIPTION
Currently the `conda_flags` parameter in https://github.com/conda-incubator/conda-store/blob/2024.3.1/conda-store-server/conda_store_server/action/generate_lockfile.py#L20 but this is not configurable.

This PR includes changes to have the `conda_flags` parameter configurable from the config py script.

## Description

We are using conda-store within nebari in one of our projects. We have a reason why we don't need strict channel priority while building the environments. The default is still `--strict-channel-priority` to be backwards compatible, but it makes the option to the user to configure different conda flags e.g. `--no-channel-priority`.

## Pull request checklist

- running tests locally
- was deployed and tested with nebari on a k8s cloud

## How to test

Add e.g. `c.CondaStore.conda_flags = "--no-channel-priority"` in the config py script.
