### PR TITLE
Add user journey test to check that logs can be found for failed builds

### DIFF
--- a/conda-store-server/tests/user_journeys/test_data/broken_environment.yaml
+++ b/conda-store-server/tests/user_journeys/test_data/broken_environment.yaml
@@ -1,0 +1,5 @@
+name: simple-broken-environment
+channels:
+  - conda-forge
+dependencies:
+  - invalidpackagenamefaasdfagksdjfhgaskdf==3.1

--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -128,3 +128,20 @@ def test_admin_delete_environment(base_url: str):
 
     assert len(api.list_environments(namespace).json()["data"]) == 0
     api.delete_namespace(namespace)
+
+
+@pytest.mark.user_journey
+def test_failed_build_logs(base_url: str):
+    """Test that a user can access logs for a failed build."""
+    api = utils.API(base_url=base_url)
+    namespace = "default"
+    build_request = api.create_environment(
+        namespace,
+        "tests/user_journeys/test_data/broken_environment.yaml",
+    ).json()
+
+    assert build_request["data"]["status"] == "FAILED"
+    assert (
+        "invalidpackagenamefaasdfagksdjfhgaskdf"
+        in api.get_logs(build_request["data"]["id"]).text
+    )

--- a/conda-store-server/tests/user_journeys/utils/api_utils.py
+++ b/conda-store-server/tests/user_journeys/utils/api_utils.py
@@ -65,6 +65,22 @@ class API:
         response.raise_for_status()
         return response
 
+    def get_logs(self, build_id: int) -> requests.Response:
+        """Get the logs for the given build id.
+
+        Parameters
+        ----------
+        build_id : int
+            ID of the build to get the logs for
+
+        Returns
+        -------
+        requests.Response
+            Response from the conda-store-server. Logs are stored in the
+            `.text` property, i.e. response.json()['text']
+        """
+        return self._make_request(f"api/v1/build/{build_id}/logs/")
+
     def _login(self, username: str, password: str) -> None:
         """Log in to the API and set an access token."""
         json_data = {"username": username, "password": password}
@@ -151,7 +167,8 @@ class API:
         Returns
         -------
         requests.Response
-            Response from the conda-store server
+            Response from the conda-store server's api/v1/build/{build_id}/
+            endpoint
         """
         with open(specification_path, "r", encoding="utf-8") as file:
             specification_content = file.read()


### PR DESCRIPTION
Fixes #672.

## Description

This PR implements a user journey test that checks that a user can access logs for a failed build.

This pull request:

- Adds a simple broken environment spec
- Implements a `get_logs` function for the user journey API utils
- Adds a test for the user journey mentioned above

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## How to test

Run the conda-store server:

```bash
docker compose up
```

Then run the test:

```bash
cd conda-store-server
pytest tests/user_journeys/test_user_journeys.py::test_failed_build_logs
```