### PR TITLE
MAINT - Add conda-store dependencies to pyproject.toml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: "Linting Checks 🧹"
         run: |
-          hatch env run -e dev lint
+          hatch env run -e lint lint
 
       - name: "Build package 📦"
         run: |
@@ -159,7 +159,7 @@ jobs:
 
       - name: "Linting Checks 🧹"
         run: |
-          hatch env run -e dev lint
+          hatch env run -e lint lint
 
       - name: "Build package 📦"
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: "Linting Checks 🧹"
         run: |
-          hatch env run -e lint lint
+          hatch env run -e dev lint
 
       - name: "Build package 📦"
         run: |

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -58,8 +58,6 @@ dependencies = [
   "constructor",
   # artifact storage
   "minio",
-  # installer
-  "constructor",
 ]
 dynamic = ["version"]
 

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -54,6 +54,8 @@ dependencies = [
   "traitlets",
   "uvicorn",
   "yarl",
+  # installer
+  "constructor",
   # artifact storage
   "minio",
   # installer
@@ -85,10 +87,10 @@ dependencies = [
   "pytest-mock",
   "pytest-playwright",
   "twine>=5.0.0",
-  "pkginfo >= 1.10",
+  "pkginfo>=1.10",
 ]
 
-[tool.hatch.envs.dev.scripts]
+[tool.hatch.envs.lint]
 lint = ["pre-commit run --all"]
 unit-test = "pytest -m 'not extended_prefix and not user_journey' tests"
 playwright-test = [

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -70,9 +70,6 @@ Source = "https://github.com/conda-incubator/conda-store"
 [tool.hatch.version]
 path = "conda_store_server/__init__.py"
 
-[project.optional-dependencies]
-dev = ["build", "twine"]
-
 [tool.hatch.envs.dev]
 dependencies = [
   "aiohttp>=3.8.1",
@@ -91,7 +88,11 @@ dependencies = [
 ]
 
 [tool.hatch.envs.lint]
+dependencies = ["pre-commit"]
+
+[tool.hatch.envs.lint.scripts]
 lint = ["pre-commit run --all"]
+
 unit-test = "pytest -m 'not extended_prefix and not user_journey' tests"
 playwright-test = [
   "playwright install",

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -26,25 +26,38 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
+  # env builds
+  # conda (which cannot be installed via pip see https://github.com/conda/conda/issues/11715)
+  "python-docker",
+  # we need platform dependent dependencies here
   "conda-docker; sys_platform == 'linux'",
+  "conda-lock >=1.0.5",
   "conda-pack",
+  "conda-package-handling",
+  "conda-package-streaming",
+  # web server
+  "alembic",
   "celery",
-  "sqlalchemy",
-  "requests",
   "fastapi",
-  "pyyaml",
-  "redis",
-  "pydantic<2",
-  "minio",
-  "traitlets",
-  "pyjwt",
-  "yarl",
   "filelock",
   "itsdangerous",
   "jinja2",
+  "pyjwt",
+  "psycopg2-binary",
+  "pymysql",
+  "pyyaml",
+  "redis",
+  "requests",
+  "pydantic<2",
   "python-multipart",
-  "python-docker"
-  # conda (which should not be included here)
+  "sqlalchemy<=1.4.47",
+  "traitlets",
+  "uvicorn",
+  "yarl",
+  # artifact storage
+  "minio",
+  # installer
+  "constructor",
 ]
 dynamic = ["version"]
 
@@ -60,20 +73,24 @@ dev = ["build", "twine"]
 
 [tool.hatch.envs.dev]
 dependencies = [
+  "aiohttp>=3.8.1",
+  "build",
+  "docker-compose",
+  "docker-py<7",
+  "flower",
+  "playwright",
   "pre-commit",
-  "sphinx",
-  "myst-parser",
-  "sphinx-panels",
-  "sphinx-copybutton",
-  "pydata-sphinx-theme",
   "pytest",
+  "pytest-celery",
   "pytest-mock",
   "pytest-playwright",
+  "twine>=5.0.0",
+  "pkginfo >= 1.10",
 ]
 
 [tool.hatch.envs.dev.scripts]
 lint = ["pre-commit run --all"]
-unit-test = "pytest tests -v"
+unit-test = "pytest -m 'not extended_prefix and not user_journey' tests"
 playwright-test = [
   "playwright install",
   "pytest --video on ../tests/test_playwright.py"

--- a/conda-store/environment.yaml
+++ b/conda-store/environment.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - pip
   - jupyterhub<2.0.0
-  - jupyterlab>=3.0.0
+  - jupyterlab>=4.0.0
   - nb_conda_kernels
   # - nb_conda_store_kernels >=0.1.4
   - nodejs=16

--- a/conda-store/pyproject.toml
+++ b/conda-store/pyproject.toml
@@ -31,7 +31,11 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Intended Audience :: System Administrators",
 ]
-dependencies = ["rich", "click", "yarl", "aiohttp", "ruamel.yaml"]
+dependencies = ["rich",
+  "click",
+  "yarl",
+  "aiohttp>=3.8.1",
+  "ruamel.yaml"]
 dynamic = ["version"]
 
 [project.urls]

--- a/conda-store/pyproject.toml
+++ b/conda-store/pyproject.toml
@@ -50,13 +50,11 @@ dev = ["build", "twine"]
 
 [tool.hatch.envs.dev]
 dependencies = [
+  "build",
   "pre-commit",
-  "sphinx",
-  "myst-parser",
-  "sphinx-panels",
-  "sphinx-copybutton",
-  "pydata-sphinx-theme",
   "pytest",
+  "twine>=5.0.0",
+  "pkginfo >= 1.10",
   "pytest-mock",
 ]
 


### PR DESCRIPTION
Split from #792 

## Description

- **BumpJLab** - now conda-store-ui is JLab >= 4.0 compatible
- **Update dev and runtime dependencies - server**
- **Update runtime dependencies - core**
- **Update dev dependencies - core**

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
## How to test

<!-- Steps to take to test the new feature, verify the bug is fixed, etc. Please do not just include steps for the happy path, but failure modes too. -->

This can be tested by building the packages with `hatch build` both for `conda-store` and `conda-store-server`
