### PR TITLE
Add user journey test to mark build as active

### DIFF
--- a/conda-store-server/tests/user_journeys/test_data/simple_environment2.yaml
+++ b/conda-store-server/tests/user_journeys/test_data/simple_environment2.yaml
@@ -1,0 +1,7 @@
+name: simple-test-environment
+channels:
+  - conda-forge
+dependencies:
+  - python ==3.10
+  - fastapi
+  - numpy

--- a/conda-store-server/tests/user_journeys/utils/api_utils.py
+++ b/conda-store-server/tests/user_journeys/utils/api_utils.py
@@ -4,7 +4,7 @@ import time
 import uuid
 
 from enum import Enum
-from typing import Union
+from typing import Any, Optional, Union
 
 import requests
 import utils.time_utils as time_utils
@@ -205,22 +205,25 @@ class API:
             f"api/v1/environment/{namespace}/{environment_name}", method="DELETE"
         )
 
-    def list_environments(self, namespace: str) -> requests.Response:
+    def list_environments(self, namespace: Optional[str] = None):
         """List the environments in the given namespace.
 
         Parameters
         ----------
-        namespace : str
-            Name of the namespace for which environments are to be retrieved
+        namespace : Optional[str]
+            Name of the namespace for which environments are to be retrieved.
+            If None, all environments are retrieved.
 
         Returns
         -------
         requests.Response
             Response from the server containing the list of environments
         """
-        return self._make_request(
-            f"api/v1/environment/?namespace={namespace}", method="GET"
-        )
+        if namespace:
+            return self._make_request(
+                f"api/v1/environment/?namespace={namespace}", method="GET"
+            )
+        return self._make_request("api/v1/environment/", method="GET")
 
     def delete_namespace(self, namespace: str) -> requests.Response:
         """Delete a namespace."""
@@ -230,3 +233,79 @@ class API:
     def gen_random_namespace() -> str:
         """Generate a random namespace."""
         return uuid.uuid4().hex
+
+    def set_active_build(
+        self, namespace: str, environment: str, build_id: int
+    ) -> requests.Response:
+        """Set the active build for a given environment.
+
+        Parameters
+        ----------
+        namespace : str
+            Name of the namespace in which the environment lives
+        environment : str
+            Environment to set the build for
+        build_id : int
+            ID of the build to be activated for the given environment
+
+        Returns
+        -------
+        requests.Response
+            Response from the conda-store server.
+        """
+        return self._make_request(
+            f"api/v1/environment/{namespace}/{environment}",
+            method="PUT",
+            json_data={"build_id": build_id},
+        )
+
+    def get_builds(
+        self,
+        environment: Optional[str] = None,
+        namespace: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Get information about an environment.
+
+        Parameters
+        ----------
+        namespace : Optional[str]
+            Name of a namespace
+        environment : Optional[str]
+            Name of an environment
+
+        Returns
+        -------
+        dict[str, Any]
+            Dict of build properties; see API docs for
+            api/v1/build/ for more information.
+        """
+        query_params = []
+        if environment:
+            query_params.append(f"name={environment}")
+
+        if namespace:
+            query_params.append(f"namespace={namespace}")
+
+        return self._make_request(f'api/v1/build/?{"&".join(query_params)}').json()[
+            "data"
+        ]
+
+    def get_environment(self, namespace: str, environment: str) -> dict[str, Any]:
+        """Get information about an environment.
+
+        Parameters
+        ----------
+        namespace : str
+            Name of the namespace in which the environment lives
+        environment : str
+            Name of the environment
+
+        Returns
+        -------
+        dict[str, Any]
+            Dict of environment properties; see API docs for
+            api/v1/environment/{namespace}/{environment}/ for more information.
+        """
+        return self._make_request(
+            f"api/v1/environment/{namespace}/{environment}/"
+        ).json()["data"]


### PR DESCRIPTION
Fixes #671.

## Description

This PR adds a user journey test which checks that an admin can activate an old build for a given environment.

This pull request:

- Adds a user journey test
- Adds a new test environment needed for the test: `simple_environment2.yaml`

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## How to test

Run the conda-store server:

```bash
docker compose up
```

Then run the test:

```bash
cd conda-store-server
pytest tests/user_journeys/test_user_journeys.py::test_admin_set_active_build
```
