### PR TITLE
Add user journey test to retrieve a lockfile for a build

### DIFF
--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -207,3 +207,22 @@ def test_cancel_build(base_url: str):
         return status == utils.BuildStatus.CANCELED
 
     utils.wait_for_condition(check_status, timeout=60, interval=1)
+
+
+@pytest.mark.user_journey
+def test_get_lockfile(base_url: str):
+    """Test that an admin can access a valid lockfile for a build."""
+    api = utils.API(base_url=base_url)
+    namespace = "default"
+    build_request = api.create_environment(
+        namespace,
+        "tests/user_journeys/test_data/simple_environment.yaml",
+    ).json()
+
+    lockfile = api.get_lockfile(build_request["data"]["id"])
+
+    packages = set(package["name"] for package in lockfile["package"])
+    assert "python" in packages
+    assert "fastapi" in packages
+
+    api.delete_environment(namespace, build_request["data"]["specification"]["name"])

--- a/conda-store-server/tests/user_journeys/utils/api_utils.py
+++ b/conda-store-server/tests/user_journeys/utils/api_utils.py
@@ -1,10 +1,11 @@
 """Helper functions for user journeys."""
 
+import json
 import time
 import uuid
 
 from enum import Enum
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import requests
 import utils.time_utils as time_utils
@@ -324,6 +325,17 @@ class API:
         """
         response = self._make_request(f"api/v1/build/{build_id}/")
         return BuildStatus(response.json()["data"]["status"])
+
+    def get_lockfile(self, build_id: int) -> Dict[str, Any]:
+        """Get a lockfile for the given build ID.
+            Build for which the lockfile is to be retrieved
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary containing the lockfile version, metadata, and packages
+        """
+        return json.loads(self._make_request(f"api/v1/build/{build_id}/lockfile").text)
 
 
 def wait_for_condition(


### PR DESCRIPTION
Fixes #673.

## Description

This PR adds a user journey test to add a lockfile for a build. Depends on #804, so I'll mark this as a draft until that one is merged.

This pull request:

- Adds a user journey test for getting a lockfile for a successful build as an admin user, and checking that it contains the expected dependencies.
- Adds a function to `api_utils.py` to retrieve the lockfile from the conda-store server

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## How to test

Run the conda-store server:

```bash
docker compose up
```

Then run the test:

```bash
cd conda-store-server
pytest tests/user_journeys/test_user_journeys.py::test_get_lockfile
```
