### PR TITLE
Implement log flushing

### DIFF
--- a/conda-store-server/conda_store_server/action/base.py
+++ b/conda-store-server/conda_store_server/action/base.py
@@ -64,7 +64,7 @@ class ActionContext:
             stderr=subprocess.STDOUT if redirect_stderr else subprocess.PIPE,
             bufsize=1,
             universal_newlines=True,
-            **kwargs
+            **kwargs,
         ) as p:
             for line in p.stdout:
                 self.stdout.write(line)

--- a/conda-store-server/conda_store_server/action/generate_constructor_installer.py
+++ b/conda-store-server/conda_store_server/action/generate_constructor_installer.py
@@ -40,7 +40,7 @@ def action_generate_constructor_installer(
             "constructor",
             "--help",
         ]
-        logged_command(context, command, timeout=10)
+        logged_command(context, command)
     except FileNotFoundError:
         warnings.warn(
             "Installer generation requires constructor: https://github.com/conda/constructor"

--- a/conda-store-server/conda_store_server/action/generate_lockfile.py
+++ b/conda-store-server/conda_store_server/action/generate_lockfile.py
@@ -1,10 +1,11 @@
-import itertools
 import json
 import os
 import pathlib
 import typing
 
 import yaml
+
+from conda_lock.conda_lock import run_lock
 
 from conda_store_server import action, conda_utils, schema
 from conda_store_server.action.utils import logged_command
@@ -48,24 +49,15 @@ def action_solve_lockfile(
     try:
         conda_flags_name = "CONDA_FLAGS"
         print(f"{conda_flags_name}={conda_flags}")
-        env = os.environ.copy()
-        env[conda_flags_name] = conda_flags
+        os.environ[conda_flags_name] = conda_flags
 
-        command = [
-            "conda-lock",
-            "lock",
-            "--file",
-            str(environment_filename),
-            "--lockfile",
-            str(lockfile_filename),
-            "--conda",
-            conda_command,
-        ]
-        if cuda_version is not None:
-            command.extend(["--with-cuda", cuda_version])
-        if platforms:
-            command.extend(itertools.chain(*[["--platform", x] for x in platforms]))
-        logged_command(context, command, env=env)
+        run_lock(
+            environment_files=[environment_filename],
+            platforms=platforms,
+            lockfile_path=lockfile_filename,
+            conda_exe=conda_command,
+            with_cuda=cuda_version,
+        )
     finally:
         os.environ.pop(conda_flags_name, None)
 

--- a/conda-store-server/conda_store_server/action/generate_lockfile.py
+++ b/conda-store-server/conda_store_server/action/generate_lockfile.py
@@ -1,11 +1,10 @@
+import itertools
 import json
 import os
 import pathlib
 import typing
 
 import yaml
-
-from conda_lock.conda_lock import run_lock
 
 from conda_store_server import action, conda_utils, schema
 from conda_store_server.action.utils import logged_command
@@ -49,15 +48,24 @@ def action_solve_lockfile(
     try:
         conda_flags_name = "CONDA_FLAGS"
         print(f"{conda_flags_name}={conda_flags}")
-        os.environ[conda_flags_name] = conda_flags
+        env = os.environ.copy()
+        env[conda_flags_name] = conda_flags
 
-        run_lock(
-            environment_files=[environment_filename],
-            platforms=platforms,
-            lockfile_path=lockfile_filename,
-            conda_exe=conda_command,
-            with_cuda=cuda_version,
-        )
+        command = [
+            "conda-lock",
+            "lock",
+            "--file",
+            str(environment_filename),
+            "--lockfile",
+            str(lockfile_filename),
+            "--conda",
+            conda_command,
+        ]
+        if cuda_version is not None:
+            command.extend(["--with-cuda", cuda_version])
+        if platforms:
+            command.extend(itertools.chain(*[["--platform", x] for x in platforms]))
+        logged_command(context, command, env=env)
     finally:
         os.environ.pop(conda_flags_name, None)
 

--- a/conda-store-server/conda_store_server/action/install_lockfile.py
+++ b/conda-store-server/conda_store_server/action/install_lockfile.py
@@ -29,4 +29,4 @@ def action_install_lockfile(
         str(lockfile_filename),
     ]
 
-    context.run(command, check=True)
+    context.run_command(command, check=True)

--- a/conda-store-server/conda_store_server/action/utils.py
+++ b/conda-store-server/conda_store_server/action/utils.py
@@ -1,10 +1,4 @@
-import subprocess
-
-
 def logged_command(context, command, **kwargs):
-    context.log.info(f"Running command: {' '.join(command)}")
-    context.log.info(
-        subprocess.check_output(
-            command, stderr=subprocess.STDOUT, encoding="utf-8", **kwargs
-        )
-    )
+    # This is here only for backward compatibility, new code should use the
+    # run_command method instead of calling this function
+    context.run_command(command, **kwargs)

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -18,6 +18,7 @@ from conda_store_server.utils import BuildPathError
 
 class LoggedStream:
     """Allows writing to storage via logging.StreamHandler"""
+
     def __init__(self, db, conda_store, build, prefix=None):
         self.db = db
         self.conda_store = conda_store
@@ -200,7 +201,12 @@ def build_conda_environment(db: Session, conda_store, build):
                 ),
                 platforms=settings.conda_solve_platforms,
                 conda_flags=conda_store.conda_flags,
-                stdout=LoggedStream(db=db, conda_store=conda_store, build=build, prefix="action_solve_lockfile: "),
+                stdout=LoggedStream(
+                    db=db,
+                    conda_store=conda_store,
+                    build=build,
+                    prefix="action_solve_lockfile: ",
+                ),
             )
 
             conda_store.storage.set(
@@ -217,13 +223,23 @@ def build_conda_environment(db: Session, conda_store, build):
             context = action.action_fetch_and_extract_conda_packages(
                 conda_lock_spec=conda_lock_spec,
                 pkgs_dir=conda_utils.conda_root_package_dir(),
-                stdout=LoggedStream(db=db, conda_store=conda_store, build=build, prefix="action_fetch_and_extract_conda_packages: "),
+                stdout=LoggedStream(
+                    db=db,
+                    conda_store=conda_store,
+                    build=build,
+                    prefix="action_fetch_and_extract_conda_packages: ",
+                ),
             )
 
             context = action.action_install_lockfile(
                 conda_lock_spec=conda_lock_spec,
                 conda_prefix=conda_prefix,
-                stdout=LoggedStream(db=db, conda_store=conda_store, build=build, prefix="action_install_lockfile: "),
+                stdout=LoggedStream(
+                    db=db,
+                    conda_store=conda_store,
+                    build=build,
+                    prefix="action_install_lockfile: ",
+                ),
             )
 
         utils.symlink(conda_prefix, environment_prefix)
@@ -233,19 +249,34 @@ def build_conda_environment(db: Session, conda_store, build):
             permissions=settings.default_permissions,
             uid=settings.default_uid,
             gid=settings.default_gid,
-            stdout=LoggedStream(db=db, conda_store=conda_store, build=build, prefix="action_set_conda_prefix_permissions: "),
+            stdout=LoggedStream(
+                db=db,
+                conda_store=conda_store,
+                build=build,
+                prefix="action_set_conda_prefix_permissions: ",
+            ),
         )
 
         action.action_add_conda_prefix_packages(
             db=db,
             conda_prefix=conda_prefix,
             build_id=build.id,
-            stdout=LoggedStream(db=db, conda_store=conda_store, build=build, prefix="action_add_conda_prefix_packages: "),
+            stdout=LoggedStream(
+                db=db,
+                conda_store=conda_store,
+                build=build,
+                prefix="action_add_conda_prefix_packages: ",
+            ),
         )
 
         context = action.action_get_conda_prefix_stats(
             conda_prefix,
-            stdout=LoggedStream(db=db, conda_store=conda_store, build=build, prefix="action_get_conda_prefix_stats: "),
+            stdout=LoggedStream(
+                db=db,
+                conda_store=conda_store,
+                build=build,
+                prefix="action_get_conda_prefix_stats: ",
+            ),
         )
         build.size = context.result["disk_usage"]
 
@@ -306,7 +337,12 @@ def build_conda_env_export(db: Session, conda_store, build: orm.Build):
     context = action.action_generate_conda_export(
         conda_command=settings.conda_command,
         conda_prefix=conda_prefix,
-        stdout=LoggedStream(db=db, conda_store=conda_store, build=build, prefix="action_generate_conda_export: "),
+        stdout=LoggedStream(
+            db=db,
+            conda_store=conda_store,
+            build=build,
+            prefix="action_generate_conda_export: ",
+        ),
     )
 
     conda_prefix_export = yaml.dump(context.result).encode("utf-8")
@@ -330,8 +366,14 @@ def build_conda_pack(db: Session, conda_store, build: orm.Build):
         with tempfile.TemporaryDirectory() as tmpdir:
             output_filename = pathlib.Path(tmpdir) / "environment.tar.gz"
             context = action.action_generate_conda_pack(
-                conda_prefix=conda_prefix, output_filename=output_filename,
-                stdout=LoggedStream(db=db, conda_store=conda_store, build=build, prefix="action_generate_conda_pack: "),
+                conda_prefix=conda_prefix,
+                output_filename=output_filename,
+                stdout=LoggedStream(
+                    db=db,
+                    conda_store=conda_store,
+                    build=build,
+                    prefix="action_generate_conda_pack: ",
+                ),
             )
             conda_store.storage.fset(
                 db,
@@ -417,7 +459,12 @@ def build_constructor_installer(db: Session, conda_store, build: orm.Build):
                 ),
                 installer_dir=pathlib.Path(tmpdir),
                 version=build.build_key,
-                stdout=LoggedStream(db=db, conda_store=conda_store, build=build, prefix="action_generate_constructor_installer: "),
+                stdout=LoggedStream(
+                    db=db,
+                    conda_store=conda_store,
+                    build=build,
+                    prefix="action_generate_constructor_installer: ",
+                ),
             )
             output_filename = context.result
             if output_filename is None:

--- a/conda-store-server/conda_store_server/build.py
+++ b/conda-store-server/conda_store_server/build.py
@@ -365,7 +365,7 @@ def build_conda_pack(db: Session, conda_store, build: orm.Build):
     ):
         with tempfile.TemporaryDirectory() as tmpdir:
             output_filename = pathlib.Path(tmpdir) / "environment.tar.gz"
-            context = action.action_generate_conda_pack(
+            action.action_generate_conda_pack(
                 conda_prefix=conda_prefix,
                 output_filename=output_filename,
                 stdout=LoggedStream(

--- a/conda-store-server/conda_store_server/storage.py
+++ b/conda-store-server/conda_store_server/storage.py
@@ -21,10 +21,17 @@ class Storage(LoggingConfigurable):
         filename: str,
         artifact_type: schema.BuildArtifactType,
     ):
-        db.add(
-            orm.BuildArtifact(build_id=build_id, key=key, artifact_type=artifact_type)
+        ba = orm.BuildArtifact
+        exists = (
+            db.query(ba)
+            .filter(ba.build_id == build_id)
+            .filter(ba.key == key)
+            .filter(ba.artifact_type == artifact_type)
+            .first()
         )
-        db.commit()
+        if not exists:
+            db.add(ba(build_id=build_id, key=key, artifact_type=artifact_type))
+            db.commit()
 
     def set(
         self,
@@ -34,10 +41,17 @@ class Storage(LoggingConfigurable):
         value: bytes,
         artifact_type: schema.BuildArtifactType,
     ):
-        db.add(
-            orm.BuildArtifact(build_id=build_id, key=key, artifact_type=artifact_type)
+        ba = orm.BuildArtifact
+        exists = (
+            db.query(ba)
+            .filter(ba.build_id == build_id)
+            .filter(ba.key == key)
+            .filter(ba.artifact_type == artifact_type)
+            .first()
         )
-        db.commit()
+        if not exists:
+            db.add(ba(build_id=build_id, key=key, artifact_type=artifact_type))
+            db.commit()
 
     def get(self, key: str):
         raise NotImplementedError()


### PR DESCRIPTION
Fixes #809.

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

<!-- What is the purpose of this pull request? -->

This pull request:
- makes actions write to log storage incrementally: the output can be seen by users as soon as it's available
- changes the logging format by prefixing each line with the name of the action: makes it easier to see what code is running
- adds locking when appending to logs to avoid a race condition
- moves the body of `logged_command` to `ActionContext.run_command`, next to `run`.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
## How to test

<!-- Steps to take to test the new feature, verify the bug is fixed, etc. Please do not just include steps for the happy path, but failure modes too. -->

- start an environment build
- go to the logs page for this build
- check that new output appears while an action is running, by refreshing the page quickly
- check that all output is prefixed with the action name