### PR TITLE
Add user journey test for canceling a build

### DIFF
--- a/conda-store-server/tests/user_journeys/test_data/complicated_environment.yaml
+++ b/conda-store-server/tests/user_journeys/test_data/complicated_environment.yaml
@@ -1,0 +1,42 @@
+name: complicated-environment
+channels:
+  - conda-forge
+  - bokeh
+dependencies:
+  - python=3.10
+  - panel
+  - ipykernel
+  - ipywidgets
+  - ipywidgets_bokeh
+  - holoviews
+  - openjdk=17.0.9
+  - pyspark
+  - findspark
+  - jhsingle-native-proxy>=0.8.2
+  - bokeh-root-cmd>=0.1.2
+  - nbconvert
+  - pip:
+      - nrtk==0.3.0
+      - xaitk-saliency==0.7.0
+      - maite==0.5.0
+      - daml==0.44.5
+      - hypothesis >=6.61.0,<7.0.0
+      - pytest >=7.2.0,<8.0
+      - pytest-cov >=4.0.0,<5.0
+      - pytest-mock >= 3.10.0,<4.0
+      - pytest-snapshot >= 0.9.0
+      - pytest-xdist >=3.3.1,<4.0.0
+      - types-python-dateutil >=2.8.19,<3.0.0
+      - tox >=4.6.4,<5.0.0
+      - virtualenv-pyenv >=0.3.0,<1.0.0
+      - jupytext >= 1.14.0
+      - numpydoc >= 1.5.0
+      - pyright >= 1.1.280
+      - loguru
+      - torch>=2.1
+      - torchmetrics
+      - torchvision
+      - multiprocess
+      - keras
+      - yolov5
+      - smqtk-detection[centernet]

--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -176,6 +176,7 @@ def test_failed_build_logs(base_url: str):
         build_request["data"]["specification"]["name"],
     )
 
+
 @pytest.mark.user_journey
 def test_cancel_build(base_url: str):
     """Test that a user cancel a build in progress."""

--- a/conda-store-server/tests/user_journeys/utils/api_utils.py
+++ b/conda-store-server/tests/user_journeys/utils/api_utils.py
@@ -4,7 +4,7 @@ import time
 import uuid
 
 from enum import Enum
-from typing import Any, Optional, Union, Callable
+from typing import Any, Callable, Optional, Union
 
 import requests
 import utils.time_utils as time_utils


### PR DESCRIPTION
Fixes #674.

## Description

This PR adds a user journey test for canceling a build.

This pull request:

- Adds a new user journey test
- Refactors some of `api_utils.py` to use a new `wait_for_condition` function to poll the conda-store-server

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## How to test

Run the conda-store server:

```bash
docker compose up
```

Then run the test:

```bash
cd conda-store-server
pytest tests/user_journeys/test_user_journeys.py::test_cancel_build
```
