### PR TITLE
Update runtime dependencies

### DIFF
--- a/conda-store-server/environment.yaml
+++ b/conda-store-server/environment.yaml
@@ -6,6 +6,3 @@ dependencies:
   - python ==3.10
   # conda environment builds
   - conda ==23.5.2
-
-  # web server
-  - flower

--- a/conda-store-server/environment.yaml
+++ b/conda-store-server/environment.yaml
@@ -6,34 +6,6 @@ dependencies:
   - python ==3.10
   # conda environment builds
   - conda ==23.5.2
-  - python-docker
-  - conda-docker >= 0.1.2
-  - conda-pack
-  - conda-lock >=1.0.5
-  - conda-package-handling
-  - conda-package-streaming
+
   # web server
-  - celery
   - flower
-  - redis-py
-  - sqlalchemy<=1.4.47
-  - alembic
-  - platformdirs >=4.0,<5.0a0
-  - psycopg2
-  - pymysql
-  - requests
-  - pyyaml
-  - uvicorn
-  - fastapi
-  - pydantic < 2.0
-  - traitlets
-  - yarl
-  - pyjwt
-  - filelock
-  - itsdangerous
-  - jinja2
-  - python-multipart
-  # artifact storage
-  - minio
-  # installer
-  - constructor

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -50,12 +50,10 @@ dependencies = [
   "requests",
   "pydantic<2",
   "python-multipart",
-  "sqlalchemy<=1.4.47",
+  "sqlalchemy<2",
   "traitlets",
   "uvicorn",
   "yarl",
-  # installer
-  "constructor",
   # artifact storage
   "minio",
   "platformdirs >=4.0,<5.0a0"
@@ -75,15 +73,12 @@ dependencies = [
   "build",
   "docker-compose",
   "docker-py<7",
-  "flower",
-  "playwright",
   "pre-commit",
   "pytest",
   "pytest-celery",
-  "pytest-mock",
   "pytest-playwright",
   "twine>=5.0.0",
-  "pkginfo>=1.10",
+  "pkginfo>=1.10", # Needed tos upport metadata 2.3
 ]
 
 [tool.hatch.envs.lint]

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "celery",
   "fastapi",
   "filelock",
+  "flower",
   "itsdangerous",
   "jinja2",
   "pyjwt",

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
   "pytest-celery",
   "pytest-playwright",
   "twine>=5.0.0",
-  "pkginfo>=1.10", # Needed tos upport metadata 2.3
+  "pkginfo>=1.10", # Needed to support metadata 2.3
 ]
 
 [tool.hatch.envs.lint]

--- a/conda-store/environment.yaml
+++ b/conda-store/environment.yaml
@@ -2,13 +2,7 @@ name: conda-store
 channels:
   - conda-forge
 dependencies:
-  - pip
-  - jupyterhub<2.0.0
-  - jupyterlab>=4.0.0
   - nb_conda_kernels
   - nodejs=18
   - yarn
   - constructor # Runtime dependency, but must be conda-installed
-  - pip:
-      - jupyter-launcher-shortcuts
-      - jupyterlab-conda-store

--- a/conda-store/environment.yaml
+++ b/conda-store/environment.yaml
@@ -6,15 +6,9 @@ dependencies:
   - jupyterhub<2.0.0
   - jupyterlab>=4.0.0
   - nb_conda_kernels
-  # - nb_conda_store_kernels >=0.1.4
-  - nodejs=16
+  - nodejs=18
   - yarn
-  # conda-store client dependencies
-  - yarl
-  - aiohttp>=3.8.1
-  - rich
-  - click
-  - ruamel.yaml
+  - constructor # Runtime dependency, but must be conda-installed
   - pip:
-      - https://github.com/yuvipanda/jupyter-launcher-shortcuts/archive/refs/heads/master.zip
+      - jupyter-launcher-shortcuts
       - jupyterlab-conda-store

--- a/conda-store/pyproject.toml
+++ b/conda-store/pyproject.toml
@@ -31,11 +31,13 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Intended Audience :: System Administrators",
 ]
-dependencies = ["rich",
+dependencies = [
+  "rich",
   "click",
   "yarl",
   "aiohttp>=3.8.1",
-  "ruamel.yaml"]
+  "ruamel.yaml",
+]
 dynamic = ["version"]
 
 [project.urls]
@@ -54,8 +56,7 @@ dependencies = [
   "pre-commit",
   "pytest",
   "twine>=5.0.0",
-  "pkginfo >= 1.10",
-  "pytest-mock",
+  "pkginfo >= 1.10", # Needed to support metadata 2.3
 ]
 
 [tool.hatch.envs.lint]

--- a/conda-store/pyproject.toml
+++ b/conda-store/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
   "yarl",
   "aiohttp>=3.8.1",
   "ruamel.yaml",
+  "jupyterhub<2.0.0",
+  "jupyterlab>=4.0.0",
+  "jupyter-launcher-shortcuts",
+  "jupyterlab-conda-store",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Description

This pull request:

This PR updates runtime dependencies in preparation for the upcoming release.

See #801 for the related PR that this one was based on. The only difference between the dependencies changed here and the ones in that PR is that I removed `pytest-mock`, which isn't being used as far as I can tell.

## Pull request checklist

- [x] Did you test this change locally? **Yes - I tried installing using fresh conda environments, only installing `conda-store/environment.yaml` and `conda-store-server/environment.yaml`. Then I did `docker compose up --build`, and was able to successfully access the UI and build an environment with `numpy` as a dependency:

![image](https://github.com/conda-incubator/conda-store/assets/14017872/073da3fb-e34b-419e-a0ac-8d79f5d40909)

- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
