### PR TITLE
ENH - Update workflows triggers

### DIFF
--- a/.github/workflows/test_build_docker_image.yaml
+++ b/.github/workflows/test_build_docker_image.yaml
@@ -6,6 +6,9 @@ env:
 
 on:
   pull_request:
+    # we do not care about building the docker image on docs changes
+    paths:
+      - "!docusaurus-docs/**"
   push:
     branches:
       - main

--- a/.github/workflows/test_conda_store.yaml
+++ b/.github/workflows/test_conda_store.yaml
@@ -6,6 +6,9 @@ env:
 
 on:
   pull_request:
+    # we do not care about building the docker image on docs changes
+    paths:
+      - "!docusaurus-docs/**"
   push:
     branches:
       - main

--- a/.github/workflows/test_conda_store_server_integration.yaml
+++ b/.github/workflows/test_conda_store_server_integration.yaml
@@ -6,6 +6,9 @@ env:
 
 on:
   pull_request:
+    # we do not care about building the docker image on docs changes
+    paths:
+      - "!docusaurus-docs/**"
   push:
     branches:
       - main

--- a/.github/workflows/test_conda_store_server_unit.yaml
+++ b/.github/workflows/test_conda_store_server_unit.yaml
@@ -6,6 +6,9 @@ env:
 
 on:
   pull_request:
+    # we do not care about building the docker image on docs changes
+    paths:
+      - "!docusaurus-docs/**"
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ conda-store-server/conda_store_server/server/static/conda-store-ui/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+docusaurus-docs/bun.lockb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-store" %}
-{% set version = "2024.1.1" %}
+{% set version = "2024.6.1" %}
 
 package:
   name: {{ name|lower }}-split
@@ -100,7 +100,7 @@ outputs:
         - conda-store-worker --help
 
 about:
-  home: https://github.com/Quansight/conda-store
+  home: https://github.com/conda-incubator/conda-store
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
@@ -110,12 +110,11 @@ about:
     philosophy of conda-store is to serve identical conda environments
     in as many ways as possible. Conda Store controls the environment
     lifecycle: management, builds, and serving of environments.
-  doc_url: https://conda-store.readthedocs.io/
-  dev_url: https://github.com/Quansight/conda-store
+  doc_url: https://conda.store
+  dev_url: https://github.com/conda-incubator/conda-store
 
 extra:
   feedstock-name: conda-store
   recipe-maintainers:
     - trallard
-    - costrouc
     - jaimergp


### PR DESCRIPTION
Since the CI takes so long, it does not make sense to run all the CI workflows when making docs-only changes.

This PR:
- **:construction_worker: CI should not run on docs**
- **:wrench: Update conda recipe** (forgot to update it recently when I updated the feedstock; please do not hate me)
