### PR TITLE
MAINT - Pin pydantic version 

### DIFF
--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "pyyaml",
   "redis",
   "requests",
-  "pydantic<2",
+  "pydantic >=1.10.16,<2.0a0",
   "python-multipart",
   "sqlalchemy<2",
   "traitlets",
@@ -80,6 +80,7 @@ dependencies = [
   "pytest-playwright",
   "twine>=5.0.0",
   "pkginfo>=1.10", # Needed to support metadata 2.3
+
 ]
 
 [tool.hatch.envs.lint]
@@ -87,14 +88,12 @@ dependencies = ["pre-commit"]
 
 [tool.hatch.envs.lint.scripts]
 lint = ["pre-commit run --all"]
-
 unit-test = "pytest -m 'not extended_prefix and not user_journey' tests"
 playwright-test = [
   "playwright install",
   "pytest --video on ../tests/test_playwright.py"
 ]
 integration-test = ["pytest ../tests/test_api.py ../tests/test_metrics.py"]
-
 user-journey-test = ["pytest -m user_journey"]
 
 [tool.hatch.build.hooks.custom]
@@ -116,6 +115,7 @@ lines_after_imports = 2
 [tool.ruff]
 ignore = [
   "E501", # line-length
+
 ]
 
 [tool.check-wheel-contents]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ outputs:
         - conda-store = conda_store.__main__:main
     requirements:
       host:
-        - python >=3.8
+        - python >=3.8,<=3.12.4
         - pip
         - hatchling >=1.14.0
         - hatch-vcs
@@ -32,7 +32,7 @@ outputs:
         - __win    # [win]
         - aiohttp>=3.8.1
         - click
-        - python >=3.8
+        - python >=3.8,<=3.12.4
         - rich
         - ruamel.yaml
         - yarl
@@ -80,7 +80,7 @@ outputs:
         # need to come back and pin =1.10.16,<2.0a0
         - pydantic <2.0a0
         - pyjwt
-        - python >=3.8
+        - python >=3.8,<=3.12.4
         - python-docker
         - python-multipart
         - pyyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ outputs:
         - conda-store = conda_store.__main__:main
     requirements:
       host:
-        - python >=3.8,<=3.12.4
+        - python >=3.8,<3.12.4
         - pip
         - hatchling >=1.14.0
         - hatch-vcs
@@ -32,7 +32,7 @@ outputs:
         - __win    # [win]
         - aiohttp>=3.8.1
         - click
-        - python >=3.8,<=3.12.4
+        - python >=3.8,<3.12.4
         - rich
         - ruamel.yaml
         - yarl
@@ -56,7 +56,7 @@ outputs:
     requirements:
       host:
         # Fix while there is a new pydantic v1 release on conda
-        - python >=3.8,<=3.12.4
+        - python >=3.8,<3.12.4
         - pip
         - hatchling >=1.14.0
         - hatch-vcs
@@ -80,7 +80,7 @@ outputs:
         # need to come back and pin =1.10.16,<2.0a0
         - pydantic <2.0a0
         - pyjwt
-        - python >=3.8,<=3.12.4
+        - python >=3.8,<3.12.4
         - python-docker
         - python-multipart
         - pyyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,8 @@ outputs:
         - conda-store-worker = conda_store_server.worker.__main__:main
     requirements:
       host:
-        - python >=3.8
+        # Fix while there is a new pydantic v1 release on conda
+        - python >=3.8,<=3.12.4
         - pip
         - hatchling >=1.14.0
         - hatch-vcs
@@ -75,7 +76,9 @@ outputs:
         - itsdangerous
         - jinja2
         - minio
-        - pydantic>=1.10.16,<2.0a0
+        # @trallard there is no updated version in conda-forge
+        # need to come back and pin =1.10.16,<2.0a0
+        - pydantic <2.0a0
         - pyjwt
         - python >=3.8
         - python-docker

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,12 +69,13 @@ outputs:
         - __win    # [win]
         - conda-pack
         - conda-lock
+        - constructor
         - fastapi
         - filelock
         - itsdangerous
         - jinja2
         - minio
-        - pydantic <2.0a0
+        - pydantic>=1.10.16,<2.0a0
         - pyjwt
         - python >=3.8
         - python-docker
@@ -86,7 +87,6 @@ outputs:
         - traitlets
         - uvicorn
         - yarl
-        - constructor
         - psycopg2
         - pymysql
       run_constrained:


### PR DESCRIPTION
We started seeing CI failures with pydantic `1.10.15` so needed to add a pin to avoid such a version

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->


## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
## How to test

<!-- Steps to take to test the new feature, verify the bug is fixed, etc. Please do not just include steps for the happy path, but failure modes too. -->
