### PR TITLE
[MAINT] Remove deprecated docker-compose config option

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   conda-store-worker:
     build:


### PR DESCRIPTION
Fixes #825.

## Description

This PR removes the deprecated `version` option from `docker-compose.yml` to avoid raising a warning every time you use it.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?