### PR TITLE
[MAINT] Prevent workers from trying to parse sys.argv upon intialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ test-results
 .ruff_cache
 
 # conda-store-ui
-conda-store-server/conda_store_server/server/static/conda-store-ui/
+conda-store-server/conda_store_server/_internal/server/static/conda-store-ui/
 
 # Docusaurus dependencies
 /node_modules

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -68,6 +68,7 @@ def conda_store_config(tmp_path):
 
     sys.argv = list(original_sys_argv)
 
+
 @pytest.fixture
 def conda_store_server(conda_store_config):
     _conda_store_server = server_app.CondaStoreServer(config=conda_store_config)

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -37,7 +37,14 @@ def celery_config(tmp_path, conda_store):
 
 
 @pytest.fixture
-def conda_store_config(tmp_path, request):
+def conda_store_config(tmp_path):
+    """A conda store configuration fixture.
+
+    sys.path is manipulated so that only the name of the called program
+    (e.g. `pytest`) is present. This prevents traitlets from parsing any
+    additional pytest args as configuration settings to be applied to
+    the conda-store-server.
+    """
     from traitlets.config import Config
 
     filename = tmp_path / ".conda-store" / "database.sqlite"
@@ -46,6 +53,9 @@ def conda_store_config(tmp_path, request):
     store_directory.mkdir(parents=True)
 
     storage.LocalStorage.storage_path = str(tmp_path / ".conda-store" / "storage")
+
+    original_sys_argv = list(sys.argv)
+    sys.argv = [sys.argv[0]]
 
     with utils.chdir(tmp_path):
         yield Config(
@@ -56,14 +66,7 @@ def conda_store_config(tmp_path, request):
             )
         )
 
-    original_sys_argv = list(sys.argv)
-    sys.argv = [sys.argv[0]]
-
-    def teardown():
-        sys.argv = list(original_sys_argv)
-
-    request.addfinalizer(teardown)
-
+    sys.argv = list(original_sys_argv)
 
 @pytest.fixture
 def conda_store_server(conda_store_config):


### PR DESCRIPTION
Fixes #849.

## Description

`CondaStoreWorker` instances subclass `traitlets.Application`. `traitlets` can parse `sys.argv` to set configuration variables for the application. In certain situations e.g. running `pytest -svv`, the worker initializes and immediately tries to parse `-svv` as a `traitlets` configuration variable, which of course does not exist.

This PR fixes the `conda_store_config` fixture, which incorrectly manipulates `sys.argv`, and inadvertently allows pytest args to get parsed as `traitlets` configuration settings.

---

Other minor change: updated the `.gitignore` to include `conda-store-ui` static files, which I missed when the privatization PR went through.

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## How to test

Here's the original offending pytest invocation, which now works as intended:

```bash
pytest tests/test_app_api.py::test_conda_store_register_environment_workflow -svv
```