### PR TITLE
Update `openapi.json` file path in `generate_api_docs.yaml`

### DIFF
--- a/.github/workflows/generate_api_docs.yaml
+++ b/.github/workflows/generate_api_docs.yaml
@@ -37,5 +37,5 @@ jobs:
         with:
           default_author: github_actions
           message: 'Update REST API documentation (openapi.json)'
-          add: 'openapi.json'
+          add: 'docusaurus-docs/static/openapi.json'
           push: true


### PR DESCRIPTION
## Description

<!-- What is the purpose of this pull request? -->

This pull request adds the complete file path to the `openapi.json` file `generate_api_docs.yaml` GitHub Action.

This path is used in a `git add` in the action. The incomplete path results in [`Error: Error: fatal: pathspec 'openapi.json' did not match any files`](https://github.com/conda-incubator/conda-store/actions/runs/10371150640/job/28710757374?pr=861#step:6:23)

Thanks for surfacing the issue, @trallard!

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

xref: #782 

## How to test

<!-- Steps to take to test the new feature, verify the bug is fixed, etc. Please do not just include steps for the happy path, but failure modes too. -->

I don't think there is a quick way to test this, besides testing on a fork.