### PR TITLE
[MAINT] Make github workflow format openapi.json

### DIFF
--- a/.github/workflows/generate_api_docs.yaml
+++ b/.github/workflows/generate_api_docs.yaml
@@ -19,7 +19,7 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - name: Install jq
+      - name: "Install jq 📦"
         run: |
           sudo apt update
           sudo apt install -y jq

--- a/.github/workflows/generate_api_docs.yaml
+++ b/.github/workflows/generate_api_docs.yaml
@@ -19,6 +19,11 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
+      - name: Install jq
+        run: |
+          sudo apt update
+          sudo apt install -y jq
+
       - name: "Checkout repository 🛎️"
         uses: actions/checkout@v4
         with:
@@ -33,7 +38,10 @@ jobs:
         run: python -m pip install conda-store-server/.
 
       - name: "Run openapi.json generation script"
-        run: python docusaurus-docs/scripts/generate_openapi_json.py
+        run: |
+          python docusaurus-docs/scripts/generate_openapi_json.py
+          jq . --sort-keys docusaurus-docs/static/openapi.json > docusaurus-docs/static/openapi.json.formatted
+          mv docusaurus-docs/static/openapi.json.formatted docusaurus-docs/static/openapi.json
 
       - name: "Commit changes"
         uses: EndBug/add-and-commit@v9

--- a/docusaurus-docs/static/openapi.json
+++ b/docusaurus-docs/static/openapi.json
@@ -1,1 +1,4230 @@
-{"openapi": "3.1.0", "info": {"title": "conda-store", "version": "2024.6.1"}, "paths": {"/login/": {"get": {"tags": ["auth"], "summary": "Get Login Method", "operationId": "get_login_method_login__get", "parameters": [{"required": false, "schema": {"type": "string", "title": "Next"}, "name": "next", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "post": {"tags": ["auth"], "summary": "Post Login Method", "operationId": "post_login_method_login__post", "parameters": [{"required": false, "schema": {"type": "string", "title": "Next"}, "name": "next", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/logout/": {"post": {"tags": ["auth"], "summary": "Post Logout Method", "operationId": "post_logout_method_logout__post", "parameters": [{"required": false, "schema": {"type": "string", "title": "Next"}, "name": "next", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/": {"get": {"tags": ["api"], "summary": "Api Status", "operationId": "api_status_api_v1__get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIGetStatus"}}}}}}}, "/api/v1/permission/": {"get": {"tags": ["api"], "summary": "Api Get Permissions", "operationId": "api_get_permissions_api_v1_permission__get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIGetPermission"}}}}}}}, "/api/v1/usage/": {"get": {"tags": ["api"], "summary": "Api Get Usage", "operationId": "api_get_usage_api_v1_usage__get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIGetUsage"}}}}}}}, "/api/v1/token/": {"post": {"tags": ["api"], "summary": "Api Post Token", "operationId": "api_post_token_api_v1_token__post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Body_api_post_token_api_v1_token__post"}}}}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIPostToken"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/namespace/": {"get": {"tags": ["api"], "summary": "Api List Namespaces", "operationId": "api_list_namespaces_api_v1_namespace__get", "parameters": [{"required": false, "schema": {"type": "integer", "title": "Page", "default": 1}, "name": "page", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Order"}, "name": "order", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Size"}, "name": "size", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Sort By", "default": []}, "name": "sort_by", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIListNamespace"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/namespace/{namespace}/": {"get": {"tags": ["api"], "summary": "Api Get Namespace", "operationId": "api_get_namespace_api_v1_namespace__namespace___get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIGetNamespace"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "put": {"tags": ["api"], "summary": "Api Update Namespace", "operationId": "api_update_namespace_api_v1_namespace__namespace___put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Body_api_update_namespace_api_v1_namespace__namespace___put"}}}}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "post": {"tags": ["api"], "summary": "Api Create Namespace", "operationId": "api_create_namespace_api_v1_namespace__namespace___post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "delete": {"tags": ["api"], "summary": "Api Delete Namespace", "operationId": "api_delete_namespace_api_v1_namespace__namespace___delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/namespace/{namespace}/metadata": {"put": {"tags": ["api"], "summary": "Api Update Namespace Metadata", "operationId": "api_update_namespace_metadata_api_v1_namespace__namespace__metadata_put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"type": "object", "title": "Metadata"}}}}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/namespace/{namespace}/roles": {"get": {"tags": ["api"], "summary": "Api Get Namespace Roles", "operationId": "api_get_namespace_roles_api_v1_namespace__namespace__roles_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "delete": {"tags": ["api"], "summary": "Api Delete Namespace Roles", "operationId": "api_delete_namespace_roles_api_v1_namespace__namespace__roles_delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/namespace/{namespace}/role": {"get": {"tags": ["api"], "summary": "Api Get Namespace Role", "operationId": "api_get_namespace_role_api_v1_namespace__namespace__role_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Other Namespace"}, "name": "other_namespace", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "put": {"tags": ["api"], "summary": "Api Update Namespace Role", "operationId": "api_update_namespace_role_api_v1_namespace__namespace__role_put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIPutNamespaceRole"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "post": {"tags": ["api"], "summary": "Api Create Namespace Role", "operationId": "api_create_namespace_role_api_v1_namespace__namespace__role_post", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIPostNamespaceRole"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "delete": {"tags": ["api"], "summary": "Api Delete Namespace Role", "operationId": "api_delete_namespace_role_api_v1_namespace__namespace__role_delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIDeleteNamespaceRole"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/environment/": {"get": {"tags": ["api"], "summary": "Api List Environments", "description": "Retrieve a list of environments.\n\nParameters\n----------\nauth : Authentication\n    Authentication instance for the request. Used to get role bindings\n    and filter environments returned to those visible by the user making\n    the request\nentity : AuthenticationToken\n    Token of the user making the request\npaginated_args : PaginatedArgs\n    Arguments for controlling pagination of the response\nconda_store : app.CondaStore\n    The running conda store application\nsearch : Optional[str]\n    If specified, filter by environment names or namespace names containing the\n    search term\nnamespace : Optional[str]\n    If specified, filter by environments in the given namespace\nname : Optional[str]\n    If specified, filter by environments with the given name\nstatus : Optional[schema.BuildStatus]\n    If specified, filter by environments with the given status\npackages : Optional[List[str]]\n    If specified, filter by environments containing the given package name(s)\nartifact : Optional[schema.BuildArtifactType]\n    If specified, filter by environments with the given BuildArtifactType\njwt : Optional[schema.AuthenticationToken]\n    If specified, retrieve only the environments accessible to this token; that is,\n    only return environments that the user has 'admin', 'editor', and 'viewer'\n    role bindings for.\n\nReturns\n-------\nDict\n    Paginated JSON response containing the requested environments", "operationId": "api_list_environments_api_v1_environment__get", "parameters": [{"required": false, "schema": {"$ref": "#/components/schemas/BuildArtifactType"}, "name": "artifact", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Jwt"}, "name": "jwt", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Name"}, "name": "name", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Packages", "default": []}, "name": "packages", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Search"}, "name": "search", "in": "query"}, {"required": false, "schema": {"$ref": "#/components/schemas/BuildStatus"}, "name": "status", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Page", "default": 1}, "name": "page", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Order"}, "name": "order", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Size"}, "name": "size", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Sort By", "default": []}, "name": "sort_by", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIListEnvironment"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/environment/{namespace}/{environment_name}/": {"get": {"tags": ["api"], "summary": "Api Get Environment", "operationId": "api_get_environment_api_v1_environment__namespace___environment_name___get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIGetEnvironment"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/environment/{namespace}/{name}/": {"put": {"tags": ["api"], "summary": "Api Update Environment Build", "operationId": "api_update_environment_build_api_v1_environment__namespace___name___put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Name"}, "name": "name", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Body_api_update_environment_build_api_v1_environment__namespace___name___put"}}}}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "delete": {"tags": ["api"], "summary": "Api Delete Environment", "operationId": "api_delete_environment_api_v1_environment__namespace___name___delete", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Name"}, "name": "name", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/specification/": {"get": {"tags": ["api"], "summary": "Api Get Specification", "operationId": "api_get_specification_api_v1_specification__get", "parameters": [{"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Channel", "default": []}, "name": "channel", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Conda", "default": []}, "name": "conda", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Pip", "default": []}, "name": "pip", "in": "query"}, {"required": false, "schema": {"allOf": [{"$ref": "#/components/schemas/APIGetSpecificationFormat"}], "default": "yaml"}, "name": "format", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "post": {"tags": ["api"], "summary": "Api Post Specification", "operationId": "api_post_specification_api_v1_specification__post", "requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/Body_api_post_specification_api_v1_specification__post"}}}}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIPostSpecification"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/": {"get": {"tags": ["api"], "summary": "Api List Builds", "operationId": "api_list_builds_api_v1_build__get", "parameters": [{"required": false, "schema": {"$ref": "#/components/schemas/BuildStatus"}, "name": "status", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Packages", "default": []}, "name": "packages", "in": "query"}, {"required": false, "schema": {"$ref": "#/components/schemas/BuildArtifactType"}, "name": "artifact", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Environment Id"}, "name": "environment_id", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Name"}, "name": "name", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Page", "default": 1}, "name": "page", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Order"}, "name": "order", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Size"}, "name": "size", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Sort By", "default": []}, "name": "sort_by", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIListBuild"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/": {"get": {"tags": ["api"], "summary": "Api Get Build", "operationId": "api_get_build_api_v1_build__build_id___get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIGetBuild"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "put": {"tags": ["api"], "summary": "Api Put Build", "operationId": "api_put_build_api_v1_build__build_id___put", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIPostSpecification"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "delete": {"tags": ["api"], "summary": "Api Delete Build", "operationId": "api_delete_build_api_v1_build__build_id___delete", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/cancel/": {"put": {"tags": ["api"], "summary": "Api Put Build Cancel", "operationId": "api_put_build_cancel_api_v1_build__build_id__cancel__put", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIAckResponse"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/packages/": {"get": {"tags": ["api"], "summary": "Api Get Build Packages", "operationId": "api_get_build_packages_api_v1_build__build_id__packages__get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Search"}, "name": "search", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Exact"}, "name": "exact", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Build"}, "name": "build", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Page", "default": 1}, "name": "page", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Order"}, "name": "order", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Size"}, "name": "size", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Sort By", "default": []}, "name": "sort_by", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIListCondaPackage"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/logs/": {"get": {"tags": ["api"], "summary": "Api Get Build Logs", "operationId": "api_get_build_logs_api_v1_build__build_id__logs__get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/channel/": {"get": {"tags": ["api"], "summary": "Api List Channels", "operationId": "api_list_channels_api_v1_channel__get", "parameters": [{"required": false, "schema": {"type": "integer", "title": "Page", "default": 1}, "name": "page", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Order"}, "name": "order", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Size"}, "name": "size", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Sort By", "default": []}, "name": "sort_by", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIListCondaChannel"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/package/": {"get": {"tags": ["api"], "summary": "Api List Packages", "operationId": "api_list_packages_api_v1_package__get", "parameters": [{"required": false, "schema": {"type": "string", "title": "Search"}, "name": "search", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Exact"}, "name": "exact", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Build"}, "name": "build", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Distinct On", "default": []}, "name": "distinct_on", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Page", "default": 1}, "name": "page", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Order"}, "name": "order", "in": "query"}, {"required": false, "schema": {"type": "integer", "title": "Size"}, "name": "size", "in": "query"}, {"required": false, "schema": {"items": {"type": "string"}, "type": "array", "title": "Sort By", "default": []}, "name": "sort_by", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIListCondaPackage"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/yaml/": {"get": {"tags": ["api"], "summary": "Api Get Build Yaml", "operationId": "api_get_build_yaml_api_v1_build__build_id__yaml__get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/lockfile/": {"get": {"tags": ["api"], "summary": "Api Get Build Lockfile", "operationId": "api_get_build_lockfile_api_v1_build__build_id__lockfile__get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"text/plain": {"schema": {"type": "string"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/conda-lock.yaml": {"get": {"tags": ["api"], "summary": "Api Get Build Conda Lock File", "operationId": "api_get_build_conda_lock_file_api_v1_build__build_id__conda_lock_yaml_get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"text/plain": {"schema": {"type": "string"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/conda-lock.yml": {"get": {"tags": ["api"], "summary": "Api Get Build Lockfile", "operationId": "api_get_build_lockfile_api_v1_build__build_id__conda_lock_yml_get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"text/plain": {"schema": {"type": "string"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/environment/{namespace}/{environment_name}/lockfile/": {"get": {"tags": ["api"], "summary": "Api Get Build Lockfile", "operationId": "api_get_build_lockfile_api_v1_environment__namespace___environment_name__lockfile__get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "path"}, {"required": false, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"text/plain": {"schema": {"type": "string"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/environment/{namespace}/{environment_name}/conda-lock.yaml": {"get": {"tags": ["api"], "summary": "Api Get Build Lockfile", "operationId": "api_get_build_lockfile_api_v1_environment__namespace___environment_name__conda_lock_yaml_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "path"}, {"required": false, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"text/plain": {"schema": {"type": "string"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/environment/{namespace}/{environment_name}/conda-lock.yml": {"get": {"tags": ["api"], "summary": "Api Get Build Lockfile", "operationId": "api_get_build_lockfile_api_v1_environment__namespace___environment_name__conda_lock_yml_get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "path"}, {"required": false, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"text/plain": {"schema": {"type": "string"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/archive/": {"get": {"tags": ["api"], "summary": "Api Get Build Archive", "operationId": "api_get_build_archive_api_v1_build__build_id__archive__get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/docker/": {"get": {"tags": ["api"], "summary": "Api Get Build Docker Image Url", "operationId": "api_get_build_docker_image_url_api_v1_build__build_id__docker__get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/build/{build_id}/installer/": {"get": {"tags": ["api"], "summary": "Api Get Build Installer", "operationId": "api_get_build_installer_api_v1_build__build_id__installer__get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/setting/{namespace}/{environment_name}/": {"get": {"tags": ["api"], "summary": "Api Get Settings", "operationId": "api_get_settings_api_v1_setting__namespace___environment_name___get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIGetSetting"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "put": {"tags": ["api"], "summary": "Api Put Settings", "operationId": "api_put_settings_api_v1_setting__namespace___environment_name___put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "path"}], "requestBody": {"content": {"application/json": {"schema": {"type": "object", "title": "Data"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIPutSetting"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/setting/{namespace}/": {"get": {"tags": ["api"], "summary": "Api Get Settings", "operationId": "api_get_settings_api_v1_setting__namespace___get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIGetSetting"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "put": {"tags": ["api"], "summary": "Api Put Settings", "operationId": "api_put_settings_api_v1_setting__namespace___put", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "query"}], "requestBody": {"content": {"application/json": {"schema": {"type": "object", "title": "Data"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIPutSetting"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/api/v1/setting/": {"get": {"tags": ["api"], "summary": "Api Get Settings", "operationId": "api_get_settings_api_v1_setting__get", "parameters": [{"required": false, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIGetSetting"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}, "put": {"tags": ["api"], "summary": "Api Put Settings", "operationId": "api_put_settings_api_v1_setting__put", "parameters": [{"required": false, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "query"}], "requestBody": {"content": {"application/json": {"schema": {"type": "object", "title": "Data"}}}, "required": true}, "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/APIPutSetting"}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/v2/": {"get": {"tags": ["registry"], "summary": "V2", "operationId": "v2_v2__get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}}}, "/v2/{rest}": {"get": {"tags": ["registry"], "summary": "List Tags", "operationId": "list_tags_v2__rest__get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Rest"}, "name": "rest", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/admin/create/": {"get": {"tags": ["ui"], "summary": "Ui Create Get Environment", "operationId": "ui_create_get_environment_admin_create__get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}}}, "/admin/": {"get": {"tags": ["ui"], "summary": "Ui List Environments", "operationId": "ui_list_environments_admin__get", "parameters": [{"required": false, "schema": {"type": "string", "title": "Search"}, "name": "search", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/admin/namespace/": {"get": {"tags": ["ui"], "summary": "Ui List Namespaces", "operationId": "ui_list_namespaces_admin_namespace__get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}}}, "/admin/environment/{namespace}/{environment_name}/": {"get": {"tags": ["ui"], "summary": "Ui Get Environment", "operationId": "ui_get_environment_admin_environment__namespace___environment_name___get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/admin/environment/{namespace}/{environment_name}/edit/": {"get": {"tags": ["ui"], "summary": "Ui Edit Environment", "operationId": "ui_edit_environment_admin_environment__namespace___environment_name__edit__get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/admin/build/{build_id}/": {"get": {"tags": ["ui"], "summary": "Ui Get Build", "operationId": "ui_get_build_admin_build__build_id___get", "parameters": [{"required": true, "schema": {"type": "integer", "title": "Build Id"}, "name": "build_id", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/admin/user/": {"get": {"tags": ["ui"], "summary": "Ui Get User", "operationId": "ui_get_user_admin_user__get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}}}, "/admin/setting/{namespace}/{environment_name}/": {"get": {"tags": ["ui"], "summary": "Ui Get Setting", "operationId": "ui_get_setting_admin_setting__namespace___environment_name___get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": true, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "path"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/admin/setting/{namespace}/": {"get": {"tags": ["ui"], "summary": "Ui Get Setting", "operationId": "ui_get_setting_admin_setting__namespace___get", "parameters": [{"required": true, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "path"}, {"required": false, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/admin/setting/": {"get": {"tags": ["ui"], "summary": "Ui Get Setting", "operationId": "ui_get_setting_admin_setting__get", "parameters": [{"required": false, "schema": {"type": "string", "title": "Namespace"}, "name": "namespace", "in": "query"}, {"required": false, "schema": {"type": "string", "title": "Environment Name"}, "name": "environment_name", "in": "query"}], "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}, "422": {"description": "Validation Error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/HTTPValidationError"}}}}}}}, "/": {"get": {"tags": ["conda-store-ui"], "summary": "Get Conda Store Ui", "operationId": "get_conda_store_ui__get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}}}, "/metrics": {"get": {"tags": ["metrics"], "summary": "Prometheus Metrics", "operationId": "prometheus_metrics_metrics_get", "responses": {"200": {"description": "Successful Response", "content": {"text/plain": {"schema": {"type": "string"}}}}}}}, "/celery": {"get": {"tags": ["metrics"], "summary": "Trigger Task", "operationId": "trigger_task_celery_get", "responses": {"200": {"description": "Successful Response", "content": {"application/json": {"schema": {}}}}}}}}, "components": {"schemas": {"APIAckResponse": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status"], "title": "APIAckResponse"}, "APIDeleteNamespaceRole": {"properties": {"other_namespace": {"type": "string", "title": "Other Namespace"}}, "type": "object", "required": ["other_namespace"], "title": "APIDeleteNamespaceRole"}, "APIGetBuild": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"$ref": "#/components/schemas/Build"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status", "data"], "title": "APIGetBuild"}, "APIGetEnvironment": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"$ref": "#/components/schemas/Environment"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status", "data"], "title": "APIGetEnvironment"}, "APIGetNamespace": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"$ref": "#/components/schemas/Namespace"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status", "data"], "title": "APIGetNamespace"}, "APIGetPermission": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"$ref": "#/components/schemas/APIGetPermissionData"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status", "data"], "title": "APIGetPermission"}, "APIGetPermissionData": {"properties": {"authenticated": {"type": "boolean", "title": "Authenticated"}, "primary_namespace": {"type": "string", "title": "Primary Namespace"}, "entity_permissions": {"additionalProperties": {"items": {"type": "string"}, "type": "array"}, "type": "object", "title": "Entity Permissions"}, "entity_roles": {"additionalProperties": {"items": {"type": "string"}, "type": "array"}, "type": "object", "title": "Entity Roles"}, "expiration": {"type": "string", "format": "date-time", "title": "Expiration"}}, "type": "object", "required": ["authenticated", "primary_namespace", "entity_permissions", "entity_roles"], "title": "APIGetPermissionData"}, "APIGetSetting": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"type": "object", "title": "Data"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status", "data"], "title": "APIGetSetting"}, "APIGetSpecificationFormat": {"enum": ["yaml", "lockfile"], "title": "APIGetSpecificationFormat", "description": "An enumeration."}, "APIGetStatus": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"$ref": "#/components/schemas/APIGetStatusData"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status", "data"], "title": "APIGetStatus"}, "APIGetStatusData": {"properties": {"version": {"type": "string", "title": "Version"}}, "type": "object", "required": ["version"], "title": "APIGetStatusData"}, "APIGetUsage": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"additionalProperties": {"type": "object"}, "type": "object", "title": "Data"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status", "data"], "title": "APIGetUsage"}, "APIListBuild": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"items": {"$ref": "#/components/schemas/Build"}, "type": "array", "title": "Data"}, "message": {"type": "string", "title": "Message"}, "page": {"type": "integer", "title": "Page"}, "size": {"type": "integer", "title": "Size"}, "count": {"type": "integer", "title": "Count"}}, "type": "object", "required": ["status", "data", "page", "size", "count"], "title": "APIListBuild"}, "APIListCondaChannel": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"items": {"$ref": "#/components/schemas/CondaChannel"}, "type": "array", "title": "Data"}, "message": {"type": "string", "title": "Message"}, "page": {"type": "integer", "title": "Page"}, "size": {"type": "integer", "title": "Size"}, "count": {"type": "integer", "title": "Count"}}, "type": "object", "required": ["status", "data", "page", "size", "count"], "title": "APIListCondaChannel"}, "APIListCondaPackage": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"items": {"$ref": "#/components/schemas/CondaPackage"}, "type": "array", "title": "Data"}, "message": {"type": "string", "title": "Message"}, "page": {"type": "integer", "title": "Page"}, "size": {"type": "integer", "title": "Size"}, "count": {"type": "integer", "title": "Count"}}, "type": "object", "required": ["status", "data", "page", "size", "count"], "title": "APIListCondaPackage"}, "APIListEnvironment": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"items": {"$ref": "#/components/schemas/Environment"}, "type": "array", "title": "Data"}, "message": {"type": "string", "title": "Message"}, "page": {"type": "integer", "title": "Page"}, "size": {"type": "integer", "title": "Size"}, "count": {"type": "integer", "title": "Count"}}, "type": "object", "required": ["status", "data", "page", "size", "count"], "title": "APIListEnvironment"}, "APIListNamespace": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"items": {"$ref": "#/components/schemas/Namespace"}, "type": "array", "title": "Data"}, "message": {"type": "string", "title": "Message"}, "page": {"type": "integer", "title": "Page"}, "size": {"type": "integer", "title": "Size"}, "count": {"type": "integer", "title": "Count"}}, "type": "object", "required": ["status", "data", "page", "size", "count"], "title": "APIListNamespace"}, "APIPostNamespaceRole": {"properties": {"other_namespace": {"type": "string", "title": "Other Namespace"}, "role": {"type": "string", "title": "Role"}}, "type": "object", "required": ["other_namespace", "role"], "title": "APIPostNamespaceRole"}, "APIPostSpecification": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"$ref": "#/components/schemas/APIPostSpecificationData"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status", "data"], "title": "APIPostSpecification"}, "APIPostSpecificationData": {"properties": {"build_id": {"type": "integer", "title": "Build Id"}}, "type": "object", "required": ["build_id"], "title": "APIPostSpecificationData"}, "APIPostToken": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"$ref": "#/components/schemas/APIPostTokenData"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status", "data"], "title": "APIPostToken"}, "APIPostTokenData": {"properties": {"token": {"type": "string", "title": "Token"}}, "type": "object", "required": ["token"], "title": "APIPostTokenData"}, "APIPutNamespaceRole": {"properties": {"other_namespace": {"type": "string", "title": "Other Namespace"}, "role": {"type": "string", "title": "Role"}}, "type": "object", "required": ["other_namespace", "role"], "title": "APIPutNamespaceRole"}, "APIPutSetting": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"title": "Data"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status"], "title": "APIPutSetting"}, "APIResponse": {"properties": {"status": {"$ref": "#/components/schemas/APIStatus"}, "data": {"title": "Data"}, "message": {"type": "string", "title": "Message"}}, "type": "object", "required": ["status"], "title": "APIResponse"}, "APIStatus": {"enum": ["ok", "error"], "title": "APIStatus", "description": "An enumeration."}, "Body_api_post_specification_api_v1_specification__post": {"properties": {"specification": {"type": "string", "title": "Specification", "default": ""}, "namespace": {"type": "string", "title": "Namespace"}, "is_lockfile": {"type": "boolean", "title": "Is Lockfile", "default": false}, "environment_name": {"type": "string", "title": "Environment Name", "default": ""}, "environment_description": {"type": "string", "title": "Environment Description", "default": ""}}, "type": "object", "title": "Body_api_post_specification_api_v1_specification__post"}, "Body_api_post_token_api_v1_token__post": {"properties": {"primary_namespace": {"type": "string", "title": "Primary Namespace"}, "expiration": {"type": "string", "format": "date-time", "title": "Expiration"}, "role_bindings": {"additionalProperties": {"items": {"type": "string"}, "type": "array"}, "type": "object", "title": "Role Bindings"}}, "type": "object", "title": "Body_api_post_token_api_v1_token__post"}, "Body_api_update_environment_build_api_v1_environment__namespace___name___put": {"properties": {"build_id": {"type": "integer", "title": "Build Id"}, "description": {"type": "string", "title": "Description"}}, "type": "object", "title": "Body_api_update_environment_build_api_v1_environment__namespace___name___put"}, "Body_api_update_namespace_api_v1_namespace__namespace___put": {"properties": {"metadata": {"type": "object", "title": "Metadata"}, "role_mappings": {"additionalProperties": {"items": {"type": "string"}, "type": "array"}, "type": "object", "title": "Role Mappings"}}, "type": "object", "title": "Body_api_update_namespace_api_v1_namespace__namespace___put"}, "Build": {"properties": {"id": {"type": "integer", "title": "Id"}, "environment_id": {"type": "integer", "title": "Environment Id"}, "specification": {"$ref": "#/components/schemas/Specification"}, "packages": {"items": {"$ref": "#/components/schemas/CondaPackage"}, "type": "array", "title": "Packages"}, "status": {"$ref": "#/components/schemas/BuildStatus"}, "status_info": {"type": "string", "title": "Status Info"}, "size": {"type": "integer", "title": "Size"}, "scheduled_on": {"type": "string", "format": "date-time", "title": "Scheduled On"}, "started_on": {"type": "string", "format": "date-time", "title": "Started On"}, "ended_on": {"type": "string", "format": "date-time", "title": "Ended On"}, "build_artifacts": {"items": {"$ref": "#/components/schemas/BuildArtifact"}, "type": "array", "title": "Build Artifacts"}}, "type": "object", "required": ["id", "environment_id", "status", "size", "scheduled_on"], "title": "Build"}, "BuildArtifact": {"properties": {"id": {"type": "integer", "title": "Id"}, "artifact_type": {"$ref": "#/components/schemas/BuildArtifactType"}, "key": {"type": "string", "title": "Key"}}, "type": "object", "required": ["id", "artifact_type", "key"], "title": "BuildArtifact"}, "BuildArtifactType": {"enum": ["DIRECTORY", "LOCKFILE", "LOGS", "YAML", "CONDA_PACK", "DOCKER_BLOB", "DOCKER_MANIFEST", "CONTAINER_REGISTRY", "CONSTRUCTOR_INSTALLER"], "title": "BuildArtifactType", "description": "An enumeration."}, "BuildStatus": {"enum": ["QUEUED", "BUILDING", "COMPLETED", "FAILED", "CANCELED"], "title": "BuildStatus", "description": "An enumeration."}, "CondaChannel": {"properties": {"id": {"type": "integer", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "last_update": {"type": "string", "format": "date-time", "title": "Last Update"}}, "type": "object", "required": ["id", "name"], "title": "CondaChannel"}, "CondaPackage": {"properties": {"id": {"type": "integer", "title": "Id"}, "channel": {"$ref": "#/components/schemas/CondaChannel"}, "license": {"type": "string", "title": "License"}, "name": {"type": "string", "title": "Name"}, "version": {"type": "string", "title": "Version"}, "summary": {"type": "string", "title": "Summary"}}, "type": "object", "required": ["id", "channel", "name", "version"], "title": "CondaPackage"}, "Environment": {"properties": {"id": {"type": "integer", "title": "Id"}, "namespace": {"$ref": "#/components/schemas/Namespace"}, "name": {"type": "string", "title": "Name"}, "current_build_id": {"type": "integer", "title": "Current Build Id"}, "current_build": {"$ref": "#/components/schemas/Build"}, "description": {"type": "string", "title": "Description"}}, "type": "object", "required": ["id", "namespace", "name", "current_build_id"], "title": "Environment"}, "HTTPValidationError": {"properties": {"detail": {"items": {"$ref": "#/components/schemas/ValidationError"}, "type": "array", "title": "Detail"}}, "type": "object", "title": "HTTPValidationError"}, "Namespace": {"properties": {"id": {"type": "integer", "title": "Id"}, "name": {"type": "string", "pattern": "^[A-Za-z0-9-+_@$&?^~.=]+$", "title": "Name"}, "metadata_": {"type": "object", "title": "Metadata "}, "role_mappings": {"items": {"$ref": "#/components/schemas/NamespaceRoleMapping"}, "type": "array", "title": "Role Mappings", "default": []}}, "type": "object", "required": ["id", "name"], "title": "Namespace"}, "NamespaceRoleMapping": {"properties": {"id": {"type": "integer", "title": "Id"}, "entity": {"type": "string", "title": "Entity"}, "role": {"type": "string", "title": "Role"}}, "type": "object", "required": ["id", "entity", "role"], "title": "NamespaceRoleMapping"}, "Specification": {"properties": {"id": {"type": "integer", "title": "Id"}, "name": {"type": "string", "title": "Name"}, "spec": {"type": "object", "title": "Spec"}, "sha256": {"type": "string", "title": "Sha256"}, "created_on": {"type": "string", "format": "date-time", "title": "Created On"}}, "type": "object", "required": ["id", "name", "spec", "sha256", "created_on"], "title": "Specification"}, "ValidationError": {"properties": {"loc": {"items": {"anyOf": [{"type": "string"}, {"type": "integer"}]}, "type": "array", "title": "Location"}, "msg": {"type": "string", "title": "Message"}, "type": {"type": "string", "title": "Error Type"}}, "type": "object", "required": ["loc", "msg", "type"], "title": "ValidationError"}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "conda-store",
+    "version": "2024.6.1"
+  },
+  "paths": {
+    "/login/": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get Login Method",
+        "operationId": "get_login_method_login__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Next"
+            },
+            "name": "next",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Post Login Method",
+        "operationId": "post_login_method_login__post",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Next"
+            },
+            "name": "next",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/logout/": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Post Logout Method",
+        "operationId": "post_logout_method_logout__post",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Next"
+            },
+            "name": "next",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Status",
+        "operationId": "api_status_api_v1__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIGetStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/permission/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Permissions",
+        "operationId": "api_get_permissions_api_v1_permission__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIGetPermission"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/usage/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Usage",
+        "operationId": "api_get_usage_api_v1_usage__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIGetUsage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/token/": {
+      "post": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Post Token",
+        "operationId": "api_post_token_api_v1_token__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_api_post_token_api_v1_token__post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIPostToken"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/namespace/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api List Namespaces",
+        "operationId": "api_list_namespaces_api_v1_namespace__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Page",
+              "default": 1
+            },
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Order"
+            },
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Size"
+            },
+            "name": "size",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Sort By",
+              "default": []
+            },
+            "name": "sort_by",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIListNamespace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/namespace/{namespace}/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Namespace",
+        "operationId": "api_get_namespace_api_v1_namespace__namespace___get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIGetNamespace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Update Namespace",
+        "operationId": "api_update_namespace_api_v1_namespace__namespace___put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_api_update_namespace_api_v1_namespace__namespace___put"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Create Namespace",
+        "operationId": "api_create_namespace_api_v1_namespace__namespace___post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Delete Namespace",
+        "operationId": "api_delete_namespace_api_v1_namespace__namespace___delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/namespace/{namespace}/metadata": {
+      "put": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Update Namespace Metadata",
+        "operationId": "api_update_namespace_metadata_api_v1_namespace__namespace__metadata_put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "Metadata"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/namespace/{namespace}/roles": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Namespace Roles",
+        "operationId": "api_get_namespace_roles_api_v1_namespace__namespace__roles_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Delete Namespace Roles",
+        "operationId": "api_delete_namespace_roles_api_v1_namespace__namespace__roles_delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/namespace/{namespace}/role": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Namespace Role",
+        "operationId": "api_get_namespace_role_api_v1_namespace__namespace__role_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Other Namespace"
+            },
+            "name": "other_namespace",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Update Namespace Role",
+        "operationId": "api_update_namespace_role_api_v1_namespace__namespace__role_put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIPutNamespaceRole"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Create Namespace Role",
+        "operationId": "api_create_namespace_role_api_v1_namespace__namespace__role_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIPostNamespaceRole"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Delete Namespace Role",
+        "operationId": "api_delete_namespace_role_api_v1_namespace__namespace__role_delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/APIDeleteNamespaceRole"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/environment/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api List Environments",
+        "description": "Retrieve a list of environments.\n\nParameters\n----------\nauth : Authentication\n    Authentication instance for the request. Used to get role bindings\n    and filter environments returned to those visible by the user making\n    the request\nentity : AuthenticationToken\n    Token of the user making the request\npaginated_args : PaginatedArgs\n    Arguments for controlling pagination of the response\nconda_store : app.CondaStore\n    The running conda store application\nsearch : Optional[str]\n    If specified, filter by environment names or namespace names containing the\n    search term\nnamespace : Optional[str]\n    If specified, filter by environments in the given namespace\nname : Optional[str]\n    If specified, filter by environments with the given name\nstatus : Optional[schema.BuildStatus]\n    If specified, filter by environments with the given status\npackages : Optional[List[str]]\n    If specified, filter by environments containing the given package name(s)\nartifact : Optional[schema.BuildArtifactType]\n    If specified, filter by environments with the given BuildArtifactType\njwt : Optional[schema.AuthenticationToken]\n    If specified, retrieve only the environments accessible to this token; that is,\n    only return environments that the user has 'admin', 'editor', and 'viewer'\n    role bindings for.\n\nReturns\n-------\nDict\n    Paginated JSON response containing the requested environments",
+        "operationId": "api_list_environments_api_v1_environment__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BuildArtifactType"
+            },
+            "name": "artifact",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Jwt"
+            },
+            "name": "jwt",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            },
+            "name": "name",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Packages",
+              "default": []
+            },
+            "name": "packages",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Search"
+            },
+            "name": "search",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BuildStatus"
+            },
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Page",
+              "default": 1
+            },
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Order"
+            },
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Size"
+            },
+            "name": "size",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Sort By",
+              "default": []
+            },
+            "name": "sort_by",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIListEnvironment"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/environment/{namespace}/{environment_name}/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Environment",
+        "operationId": "api_get_environment_api_v1_environment__namespace___environment_name___get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIGetEnvironment"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/environment/{namespace}/{name}/": {
+      "put": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Update Environment Build",
+        "operationId": "api_update_environment_build_api_v1_environment__namespace___name___put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            },
+            "name": "name",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_api_update_environment_build_api_v1_environment__namespace___name___put"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Delete Environment",
+        "operationId": "api_delete_environment_api_v1_environment__namespace___name___delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            },
+            "name": "name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/specification/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Specification",
+        "operationId": "api_get_specification_api_v1_specification__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Channel",
+              "default": []
+            },
+            "name": "channel",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Conda",
+              "default": []
+            },
+            "name": "conda",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Pip",
+              "default": []
+            },
+            "name": "pip",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/APIGetSpecificationFormat"
+                }
+              ],
+              "default": "yaml"
+            },
+            "name": "format",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Post Specification",
+        "operationId": "api_post_specification_api_v1_specification__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_api_post_specification_api_v1_specification__post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIPostSpecification"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api List Builds",
+        "operationId": "api_list_builds_api_v1_build__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BuildStatus"
+            },
+            "name": "status",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Packages",
+              "default": []
+            },
+            "name": "packages",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BuildArtifactType"
+            },
+            "name": "artifact",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Environment Id"
+            },
+            "name": "environment_id",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            },
+            "name": "name",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Page",
+              "default": 1
+            },
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Order"
+            },
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Size"
+            },
+            "name": "size",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Sort By",
+              "default": []
+            },
+            "name": "sort_by",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIListBuild"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build",
+        "operationId": "api_get_build_api_v1_build__build_id___get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIGetBuild"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Put Build",
+        "operationId": "api_put_build_api_v1_build__build_id___put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIPostSpecification"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Delete Build",
+        "operationId": "api_delete_build_api_v1_build__build_id___delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/cancel/": {
+      "put": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Put Build Cancel",
+        "operationId": "api_put_build_cancel_api_v1_build__build_id__cancel__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIAckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/packages/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Packages",
+        "operationId": "api_get_build_packages_api_v1_build__build_id__packages__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Search"
+            },
+            "name": "search",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Exact"
+            },
+            "name": "exact",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Build"
+            },
+            "name": "build",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Page",
+              "default": 1
+            },
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Order"
+            },
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Size"
+            },
+            "name": "size",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Sort By",
+              "default": []
+            },
+            "name": "sort_by",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIListCondaPackage"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/logs/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Logs",
+        "operationId": "api_get_build_logs_api_v1_build__build_id__logs__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/channel/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api List Channels",
+        "operationId": "api_list_channels_api_v1_channel__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Page",
+              "default": 1
+            },
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Order"
+            },
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Size"
+            },
+            "name": "size",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Sort By",
+              "default": []
+            },
+            "name": "sort_by",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIListCondaChannel"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/package/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api List Packages",
+        "operationId": "api_list_packages_api_v1_package__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Search"
+            },
+            "name": "search",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Exact"
+            },
+            "name": "exact",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Build"
+            },
+            "name": "build",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Distinct On",
+              "default": []
+            },
+            "name": "distinct_on",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Page",
+              "default": 1
+            },
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Order"
+            },
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Size"
+            },
+            "name": "size",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Sort By",
+              "default": []
+            },
+            "name": "sort_by",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIListCondaPackage"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/yaml/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Yaml",
+        "operationId": "api_get_build_yaml_api_v1_build__build_id__yaml__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/lockfile/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Lockfile",
+        "operationId": "api_get_build_lockfile_api_v1_build__build_id__lockfile__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/conda-lock.yaml": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Conda Lock File",
+        "operationId": "api_get_build_conda_lock_file_api_v1_build__build_id__conda_lock_yaml_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/conda-lock.yml": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Lockfile",
+        "operationId": "api_get_build_lockfile_api_v1_build__build_id__conda_lock_yml_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/environment/{namespace}/{environment_name}/lockfile/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Lockfile",
+        "operationId": "api_get_build_lockfile_api_v1_environment__namespace___environment_name__lockfile__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/environment/{namespace}/{environment_name}/conda-lock.yaml": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Lockfile",
+        "operationId": "api_get_build_lockfile_api_v1_environment__namespace___environment_name__conda_lock_yaml_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/environment/{namespace}/{environment_name}/conda-lock.yml": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Lockfile",
+        "operationId": "api_get_build_lockfile_api_v1_environment__namespace___environment_name__conda_lock_yml_get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/archive/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Archive",
+        "operationId": "api_get_build_archive_api_v1_build__build_id__archive__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/docker/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Docker Image Url",
+        "operationId": "api_get_build_docker_image_url_api_v1_build__build_id__docker__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/build/{build_id}/installer/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Build Installer",
+        "operationId": "api_get_build_installer_api_v1_build__build_id__installer__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/setting/{namespace}/{environment_name}/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Settings",
+        "operationId": "api_get_settings_api_v1_setting__namespace___environment_name___get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIGetSetting"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Put Settings",
+        "operationId": "api_put_settings_api_v1_setting__namespace___environment_name___put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIPutSetting"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/setting/{namespace}/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Settings",
+        "operationId": "api_get_settings_api_v1_setting__namespace___get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIGetSetting"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Put Settings",
+        "operationId": "api_put_settings_api_v1_setting__namespace___put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIPutSetting"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/setting/": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Get Settings",
+        "operationId": "api_get_settings_api_v1_setting__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIGetSetting"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Api Put Settings",
+        "operationId": "api_put_settings_api_v1_setting__put",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "title": "Data"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIPutSetting"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/": {
+      "get": {
+        "tags": [
+          "registry"
+        ],
+        "summary": "V2",
+        "operationId": "v2_v2__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{rest}": {
+      "get": {
+        "tags": [
+          "registry"
+        ],
+        "summary": "List Tags",
+        "operationId": "list_tags_v2__rest__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Rest"
+            },
+            "name": "rest",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/create/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui Create Get Environment",
+        "operationId": "ui_create_get_environment_admin_create__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui List Environments",
+        "operationId": "ui_list_environments_admin__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Search"
+            },
+            "name": "search",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/namespace/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui List Namespaces",
+        "operationId": "ui_list_namespaces_admin_namespace__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/environment/{namespace}/{environment_name}/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui Get Environment",
+        "operationId": "ui_get_environment_admin_environment__namespace___environment_name___get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/environment/{namespace}/{environment_name}/edit/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui Edit Environment",
+        "operationId": "ui_edit_environment_admin_environment__namespace___environment_name__edit__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/build/{build_id}/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui Get Build",
+        "operationId": "ui_get_build_admin_build__build_id___get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Build Id"
+            },
+            "name": "build_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/user/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui Get User",
+        "operationId": "ui_get_user_admin_user__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/setting/{namespace}/{environment_name}/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui Get Setting",
+        "operationId": "ui_get_setting_admin_setting__namespace___environment_name___get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/setting/{namespace}/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui Get Setting",
+        "operationId": "ui_get_setting_admin_setting__namespace___get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/setting/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui Get Setting",
+        "operationId": "ui_get_setting_admin_setting__get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            },
+            "name": "namespace",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Environment Name"
+            },
+            "name": "environment_name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "tags": [
+          "conda-store-ui"
+        ],
+        "summary": "Get Conda Store Ui",
+        "operationId": "get_conda_store_ui__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "tags": [
+          "metrics"
+        ],
+        "summary": "Prometheus Metrics",
+        "operationId": "prometheus_metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/celery": {
+      "get": {
+        "tags": [
+          "metrics"
+        ],
+        "summary": "Trigger Task",
+        "operationId": "trigger_task_celery_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "APIAckResponse": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "APIAckResponse"
+      },
+      "APIDeleteNamespaceRole": {
+        "properties": {
+          "other_namespace": {
+            "type": "string",
+            "title": "Other Namespace"
+          }
+        },
+        "type": "object",
+        "required": [
+          "other_namespace"
+        ],
+        "title": "APIDeleteNamespaceRole"
+      },
+      "APIGetBuild": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "$ref": "#/components/schemas/Build"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "title": "APIGetBuild"
+      },
+      "APIGetEnvironment": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "$ref": "#/components/schemas/Environment"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "title": "APIGetEnvironment"
+      },
+      "APIGetNamespace": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "$ref": "#/components/schemas/Namespace"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "title": "APIGetNamespace"
+      },
+      "APIGetPermission": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "$ref": "#/components/schemas/APIGetPermissionData"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "title": "APIGetPermission"
+      },
+      "APIGetPermissionData": {
+        "properties": {
+          "authenticated": {
+            "type": "boolean",
+            "title": "Authenticated"
+          },
+          "primary_namespace": {
+            "type": "string",
+            "title": "Primary Namespace"
+          },
+          "entity_permissions": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Entity Permissions"
+          },
+          "entity_roles": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Entity Roles"
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expiration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "authenticated",
+          "primary_namespace",
+          "entity_permissions",
+          "entity_roles"
+        ],
+        "title": "APIGetPermissionData"
+      },
+      "APIGetSetting": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "type": "object",
+            "title": "Data"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "title": "APIGetSetting"
+      },
+      "APIGetSpecificationFormat": {
+        "enum": [
+          "yaml",
+          "lockfile"
+        ],
+        "title": "APIGetSpecificationFormat",
+        "description": "An enumeration."
+      },
+      "APIGetStatus": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "$ref": "#/components/schemas/APIGetStatusData"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "title": "APIGetStatus"
+      },
+      "APIGetStatusData": {
+        "properties": {
+          "version": {
+            "type": "string",
+            "title": "Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "title": "APIGetStatusData"
+      },
+      "APIGetUsage": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "additionalProperties": {
+              "type": "object"
+            },
+            "type": "object",
+            "title": "Data"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "title": "APIGetUsage"
+      },
+      "APIListBuild": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Build"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data",
+          "page",
+          "size",
+          "count"
+        ],
+        "title": "APIListBuild"
+      },
+      "APIListCondaChannel": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CondaChannel"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data",
+          "page",
+          "size",
+          "count"
+        ],
+        "title": "APIListCondaChannel"
+      },
+      "APIListCondaPackage": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CondaPackage"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data",
+          "page",
+          "size",
+          "count"
+        ],
+        "title": "APIListCondaPackage"
+      },
+      "APIListEnvironment": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Environment"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data",
+          "page",
+          "size",
+          "count"
+        ],
+        "title": "APIListEnvironment"
+      },
+      "APIListNamespace": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Namespace"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data",
+          "page",
+          "size",
+          "count"
+        ],
+        "title": "APIListNamespace"
+      },
+      "APIPostNamespaceRole": {
+        "properties": {
+          "other_namespace": {
+            "type": "string",
+            "title": "Other Namespace"
+          },
+          "role": {
+            "type": "string",
+            "title": "Role"
+          }
+        },
+        "type": "object",
+        "required": [
+          "other_namespace",
+          "role"
+        ],
+        "title": "APIPostNamespaceRole"
+      },
+      "APIPostSpecification": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "$ref": "#/components/schemas/APIPostSpecificationData"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "title": "APIPostSpecification"
+      },
+      "APIPostSpecificationData": {
+        "properties": {
+          "build_id": {
+            "type": "integer",
+            "title": "Build Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "build_id"
+        ],
+        "title": "APIPostSpecificationData"
+      },
+      "APIPostToken": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "$ref": "#/components/schemas/APIPostTokenData"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "data"
+        ],
+        "title": "APIPostToken"
+      },
+      "APIPostTokenData": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token"
+        ],
+        "title": "APIPostTokenData"
+      },
+      "APIPutNamespaceRole": {
+        "properties": {
+          "other_namespace": {
+            "type": "string",
+            "title": "Other Namespace"
+          },
+          "role": {
+            "type": "string",
+            "title": "Role"
+          }
+        },
+        "type": "object",
+        "required": [
+          "other_namespace",
+          "role"
+        ],
+        "title": "APIPutNamespaceRole"
+      },
+      "APIPutSetting": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "title": "Data"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "APIPutSetting"
+      },
+      "APIResponse": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/APIStatus"
+          },
+          "data": {
+            "title": "Data"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "APIResponse"
+      },
+      "APIStatus": {
+        "enum": [
+          "ok",
+          "error"
+        ],
+        "title": "APIStatus",
+        "description": "An enumeration."
+      },
+      "Body_api_post_specification_api_v1_specification__post": {
+        "properties": {
+          "specification": {
+            "type": "string",
+            "title": "Specification",
+            "default": ""
+          },
+          "namespace": {
+            "type": "string",
+            "title": "Namespace"
+          },
+          "is_lockfile": {
+            "type": "boolean",
+            "title": "Is Lockfile",
+            "default": false
+          },
+          "environment_name": {
+            "type": "string",
+            "title": "Environment Name",
+            "default": ""
+          },
+          "environment_description": {
+            "type": "string",
+            "title": "Environment Description",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "Body_api_post_specification_api_v1_specification__post"
+      },
+      "Body_api_post_token_api_v1_token__post": {
+        "properties": {
+          "primary_namespace": {
+            "type": "string",
+            "title": "Primary Namespace"
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expiration"
+          },
+          "role_bindings": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Role Bindings"
+          }
+        },
+        "type": "object",
+        "title": "Body_api_post_token_api_v1_token__post"
+      },
+      "Body_api_update_environment_build_api_v1_environment__namespace___name___put": {
+        "properties": {
+          "build_id": {
+            "type": "integer",
+            "title": "Build Id"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "title": "Body_api_update_environment_build_api_v1_environment__namespace___name___put"
+      },
+      "Body_api_update_namespace_api_v1_namespace__namespace___put": {
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "title": "Metadata"
+          },
+          "role_mappings": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Role Mappings"
+          }
+        },
+        "type": "object",
+        "title": "Body_api_update_namespace_api_v1_namespace__namespace___put"
+      },
+      "Build": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "environment_id": {
+            "type": "integer",
+            "title": "Environment Id"
+          },
+          "specification": {
+            "$ref": "#/components/schemas/Specification"
+          },
+          "packages": {
+            "items": {
+              "$ref": "#/components/schemas/CondaPackage"
+            },
+            "type": "array",
+            "title": "Packages"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BuildStatus"
+          },
+          "status_info": {
+            "type": "string",
+            "title": "Status Info"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "scheduled_on": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Scheduled On"
+          },
+          "started_on": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started On"
+          },
+          "ended_on": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Ended On"
+          },
+          "build_artifacts": {
+            "items": {
+              "$ref": "#/components/schemas/BuildArtifact"
+            },
+            "type": "array",
+            "title": "Build Artifacts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "environment_id",
+          "status",
+          "size",
+          "scheduled_on"
+        ],
+        "title": "Build"
+      },
+      "BuildArtifact": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "artifact_type": {
+            "$ref": "#/components/schemas/BuildArtifactType"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "artifact_type",
+          "key"
+        ],
+        "title": "BuildArtifact"
+      },
+      "BuildArtifactType": {
+        "enum": [
+          "DIRECTORY",
+          "LOCKFILE",
+          "LOGS",
+          "YAML",
+          "CONDA_PACK",
+          "DOCKER_BLOB",
+          "DOCKER_MANIFEST",
+          "CONTAINER_REGISTRY",
+          "CONSTRUCTOR_INSTALLER"
+        ],
+        "title": "BuildArtifactType",
+        "description": "An enumeration."
+      },
+      "BuildStatus": {
+        "enum": [
+          "QUEUED",
+          "BUILDING",
+          "COMPLETED",
+          "FAILED",
+          "CANCELED"
+        ],
+        "title": "BuildStatus",
+        "description": "An enumeration."
+      },
+      "CondaChannel": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "last_update": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Update"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "CondaChannel"
+      },
+      "CondaPackage": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/CondaChannel"
+          },
+          "license": {
+            "type": "string",
+            "title": "License"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "channel",
+          "name",
+          "version"
+        ],
+        "title": "CondaPackage"
+      },
+      "Environment": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "namespace": {
+            "$ref": "#/components/schemas/Namespace"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "current_build_id": {
+            "type": "integer",
+            "title": "Current Build Id"
+          },
+          "current_build": {
+            "$ref": "#/components/schemas/Build"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "namespace",
+          "name",
+          "current_build_id"
+        ],
+        "title": "Environment"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Namespace": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9-+_@$&?^~.=]+$",
+            "title": "Name"
+          },
+          "metadata_": {
+            "type": "object",
+            "title": "Metadata "
+          },
+          "role_mappings": {
+            "items": {
+              "$ref": "#/components/schemas/NamespaceRoleMapping"
+            },
+            "type": "array",
+            "title": "Role Mappings",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "Namespace"
+      },
+      "NamespaceRoleMapping": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "entity": {
+            "type": "string",
+            "title": "Entity"
+          },
+          "role": {
+            "type": "string",
+            "title": "Role"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "entity",
+          "role"
+        ],
+        "title": "NamespaceRoleMapping"
+      },
+      "Specification": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "spec": {
+            "type": "object",
+            "title": "Spec"
+          },
+          "sha256": {
+            "type": "string",
+            "title": "Sha256"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created On"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "spec",
+          "sha256",
+          "created_on"
+        ],
+        "title": "Specification"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #870.

## Description

This pull request runs `jq` to format the generated `openapi.json` in a more human readable format. This also inserts a newline at the end of the file so that `pre-commit.ci` stops failing on all PRs.

I've also made `jq` sort the json by keys, which should make the order nice and stable.

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?