### PR TITLE
Set logout url properly when using the integrated ui

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/templates/conda-store-ui.html
+++ b/conda-store-server/conda_store_server/_internal/server/templates/conda-store-ui.html
@@ -24,6 +24,7 @@ https://conda.store/conda-store-ui/how-tos/configure-ui -->
              REACT_APP_SHOW_LOGIN_ICON: "true",
              REACT_APP_API_URL: "{{ url_for('get_conda_store_ui') }}",
              REACT_APP_LOGIN_PAGE_URL: "{{ url_for('get_login_method') }}?next=",
+             REACT_APP_LOGOUT_PAGE_URL: "{{ url_for('post_logout_method') }}?next=/",
          };
         </script>
         <script defer src="static/conda-store-ui/main.js"></script>


### PR DESCRIPTION
Properly sets the logout url when using the integrated ui.

Fixes https://github.com/nebari-dev/nebari/issues/2717 

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

Currently, using the `c.CondaStoreServer.enable_ui = True` configuration option uses conda-store-ui with the following config:
```python
var condaStoreConfig = {
             NODE_DEBUG: null,
             REACT_APP_CONTEXT: "single-page-app", // not a true setting
             REACT_APP_AUTH_METHOD: "cookie",
             REACT_APP_AUTH_TOKEN: "",
             REACT_APP_STYLE_TYPE: "green-accent",
             REACT_APP_SHOW_LOGIN_ICON: "true",
             REACT_APP_API_URL: "{{ url_for('get_conda_store_ui') }}",
             REACT_APP_LOGIN_PAGE_URL: "{{ url_for('get_login_method') }}?next=",
         };
```

The fact that the logout url is not set results in logout not working. We can see in https://nebari.quansight.dev/conda-store/ that the logout route is set to the default value.

![Screenshot from 2024-09-17 17-48-41](https://github.com/user-attachments/assets/24bd0713-3f1c-4c7e-a952-291d6597e6b6)


This pull request:

- Adds the `REACT_APP_LOGOUT_PAGE_URL` configuration option to the invocation of conda-store-ui.


## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [X] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
## How to test

Start conda-store-server with the `c.CondaStoreServer.enable_ui = True`.
Load the ui and login
Logout

<!-- Steps to take to test the new feature, verify the bug is fixed, etc. Please do not just include steps for the happy path, but failure modes too. -->
