### PR TITLE
[BUG] Fix openapi.json generation workflow

### DIFF
--- a/.github/workflows/generate_api_docs.yaml
+++ b/.github/workflows/generate_api_docs.yaml
@@ -1,33 +1,22 @@
 name: "Generate openapi.json"
 
-env:
-  DEFAULT_PYTHON_VERSION: "3.12"
-
 on:
-  pull_request:
-    paths: ['conda-store-server/conda_store_server/**']
+  workflow_dispatch:
+  schedule:
+    - cron: "15 0 * * 0"   # Run at 00:15 every Sunday
 
 jobs:
   update-openapi-json:
     runs-on: ubuntu-latest
-    # so that we can skip this job by adding 'skip openapi' to the commit message
-    # and only run it when the PR is against the main branch of our repo
-    if: "!contains(github.event.head_commit.message, '[openapi skip]') && github.repository=='conda-incubator/conda-store'"
     permissions:
       contents: write
+      pull-requests: write
     defaults:
       run:
         shell: bash -el {0}
     steps:
-      - name: "Install jq 📦"
-        run: |
-          sudo apt update
-          sudo apt install -y jq
-
       - name: "Checkout repository 🛎️"
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: "Set up Miniconda 🐍"
         uses: conda-incubator/setup-miniconda@v3
@@ -43,10 +32,14 @@ jobs:
           jq . --sort-keys docusaurus-docs/static/openapi.json > docusaurus-docs/static/openapi.json.formatted
           mv docusaurus-docs/static/openapi.json.formatted docusaurus-docs/static/openapi.json
 
-      - name: "Commit changes"
-        uses: EndBug/add-and-commit@v9
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
         with:
-          default_author: github_actions
-          message: 'Update REST API documentation (openapi.json)'
-          add: 'docusaurus-docs/static/openapi.json'
-          push: true
+          title: "[AUTO] Update openapi.json"
+          commit-message: "[AUTO] Update openapi.json"
+          add-paths: docusaurus-docs/static/openapi.json
+          labels: |
+            needs: review 👀
+            type: maintenance 🛠
+            area: api
+            area: documentation 📖


### PR DESCRIPTION
Fixes #888.

## Description

Apparently `github.event.pull_request.head.ref` isn't always guaranteed to exist on pull requests. The docs for `EndBug/add-and-commit` suggest using this ref because otherwise the branch is checked out in a detached head state. A simple search for "how to add and commit in github actions" turns up a bunch of results that suggest that in fact you can just call `actions/checkout` and then `git add .; git commit -m <message>; git push`, so I'm not really sure who is right. The PR tests out the second approach.

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Update

This PR doesn't actually trigger the workflow that updates openapi.json, but I've been trying it on https://github.com/conda-incubator/conda-store/pull/881:

1. Checking out with the `github.event.pull_request.head.ref`, which doesn't exist sometimes:

```yaml
      - name: "Checkout repository 🛎️"
        uses: actions/checkout@v4
        with:
          ref: ${{ github.event.pull_request.head.ref }}
```

2. Not checking out specific ref:

```yaml
        with:
          ref: ${{ github.event.pull_request.head.ref }}
```

3. Checking out with `fetch-depth: 0`:

```yaml
        with:
          ref: ${{ github.event.pull_request.head.ref }}
          fetch-depth: 0
```

4. Checking out without a specific ref and with `fetch-depth: 0`:

```yaml
        with:
          fetch-depth: 0
```

5. Checking out with `github.head_ref`:

```yaml
        with:
          ref: ${{ github.head_ref }}
```

6. Checking out with `fetch-depth: 0`:

```yaml
        with:
          ref: ${{ github.head_ref }}
          fetch-depth: 0
```

It seems like this might not be possible [according to this community discussion](https://github.com/orgs/community/discussions/32032), or it should be possible according to [this](https://joht.github.io/johtizen/build/2022/01/20/github-actions-push-into-repository.html), [this](https://github.com/orgs/community/discussions/24945#discussioncomment-3245946), [this](https://github.com/EndBug/add-and-commit), and [this](https://github.com/stefanzweifel/git-auto-commit-action), but it's unclear if these work on PRs coming from forks. [This](https://stackoverflow.com/a/64078507/8100451) suggests that I need to use a personal access token rather than the `GITHUB_TOKEN` generated during workflows, but would be suboptimal because we'd have to switch it out if whoever owns it eventually moves on from conda-store development. I thought about trying to do what pre-commit.ci does, [but it's quite convoluted](https://github.com/pre-commit-ci/lite-action): its entrypoint is a js module which spawns a python subprocess (??) which clones and then copies your branch, then does a cherry-pick (???) to get the formatted changes in. [This](https://github.com/jupyterlab/jupyterlab/blob/main/.github/workflows/galata-update.yml) approach checks out correctly if I replace `github.event.issue.number` with `github.event.pull_request.number`, but then fails with a permissions error despite using `secrets.GITHUB_TOKEN` with the permissions set to

```yaml
permissions:
  contents: write
  pull-requests: write
```

in the commit/push step.