### PR TITLE
Create local conda-store dir for celery beat data files

### DIFF
--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -61,7 +61,10 @@ RUN mamba create --name ${conda_env_name} \
 COPY ./ /opt/conda-store-server/
 
 USER 0:0
-RUN chown -R ${user_no}:${user_no} /opt/conda-store-server/
+RUN chown -R ${user_no}:${user_no} /opt/conda-store-server/ && \
+ mkdir -p /.local/share/conda-store && \
+ chown -R ${user_no}:${user_no} /.local/share/conda-store 
+
 USER ${user_no}:${user_no}
 
 # ---------------------------------------------------------------------------------

--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -63,7 +63,7 @@ COPY ./ /opt/conda-store-server/
 USER 0:0
 RUN chown -R ${user_no}:${user_no} /opt/conda-store-server/ && \
  mkdir -p /.local/share/conda-store && \
- chown -R ${user_no}:${user_no} /.local/share/conda-store 
+ chown -R ${user_no}:${user_no} /.local/share/conda-store
 
 USER ${user_no}:${user_no}
 


### PR DESCRIPTION
## Description

Previously, when running `docker compose up -d` the worker container would have some errors output because it is not able to create it's celery beat file. For example,

```
$ docker compose up 
. . .
conda-store-worker-1  | [2024-10-19 00:44:41,925: INFO/Beat] beat: Starting...
conda-store-worker-1  | [2024-10-19 00:44:41,952: ERROR/Beat] Removing corrupted schedule file '/.local/share/conda-store/celerybeat-schedule': FileNotFoundError(2, 'No such file or directory')
. . .

conda-store-worker-1  | [2024-10-19 00:44:41,967: WARNING/Beat] FileNotFoundError: [Errno 2] No such file or directory: b'/.local/share/conda-store/celerybeat-schedule.dat'
. . .
```

This PR creates the missing directory and gives the user permission to it so celery can create it's beat file. Now the output is:

```
$ docker compose up
. . .
conda-store-worker-1  | [2024-10-19 00:48:24,340: INFO/Beat] beat: Starting...
. . .
```

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

