### PR TITLE
Respect worker log level config setting

### DIFF
--- a/conda-store-server/conda_store_server/_internal/worker/app.py
+++ b/conda-store-server/conda_store_server/_internal/worker/app.py
@@ -72,10 +72,23 @@ class CondaStoreWorker(Application):
         # ensure checks on redis_url
         self.conda_store.redis_url
 
+    def logger_to_celery_logging_level(self, logging_level):
+        # celery supports the log levels DEBUG | INFO | WARNING | ERROR | CRITICAL | FATAL
+        # https://docs.celeryq.dev/en/main/reference/cli.html#celery-worker
+        logging_to_celery_level_map = {
+            50: "CRITICAL",
+            40: "ERROR",
+            30: "WARNING",
+            20: "INFO",
+            10: "DEBUG",
+        }
+        return logging_to_celery_level_map[logging_level]
+
     def start(self):
+
         argv = [
             "worker",
-            "--loglevel=INFO",
+            f"--loglevel={self.logger_to_celery_logging_level(self.log_level)}",
             "--max-tasks-per-child=10",  # mitigate memory leaks
         ]
 


### PR DESCRIPTION
## Description

This small PR updates the conda store worker to respect the `CondaStoreWorker.log_level` config parameter. Now users can see that the log level set for their works gets applied to the worker.

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?


## How to test

Before this change, the worker was always running at `logger.INFO` log level. For example, you can see in the log output
```
. . .
conda-store-worker-1  | [2024-10-19 01:41:55,960: INFO/MainProcess] Connected to redis://:**@redis:6379/0
conda-store-worker-1  | [2024-10-19 01:41:55,962: WARNING/MainProcess] /opt/conda/envs/conda-store-server/lib/python3.12/site-packages/celery/worker/consumer/consumer.py:508: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
```

To test this add the following line to your conda-store config file

```
c.CondaStoreWorker.log_level = logging.ERROR
```

Restart the server and view the logs. Notice that the WARN and INFO log lines no longer appear in the logs.

