### PR TITLE
DEV - Extend compose to include target for local UI

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -68,6 +68,7 @@ Release captain responsible - <@gh_username>
 - [ ] Update the [conda-forge feedstock version](https://github.com/conda-forge/conda-store-feedstock) through a PR or review and merge the regro-bot PR.
   - [ ] If needed - update `meta.yaml` or `recipe.yaml` and re-render the feedstock.
 - [ ] Open a follow-up PR to bump `conda-store` and `conda-store-server` versions to the next dev-release number (for example `2024.10.1`).
+- [ ] Open a follow-up PR to bump the `conda-store-server` version in the [`conda-store-ui` compose file](https://github.com/conda-incubator/conda-store-ui/blob/main/docker-compose.yml).
 - [ ] Celebrate, you're done! 🎉
 
 [^github-activity]: If you wish, use [`github-activity` to generate a Changelog](https://github.com/choldgraf/github-activity), e.g. `github-activity conda-incubator/conda-store --since 2024.9.1 --until 2023.10.1`.

--- a/conda-store-server/Dockerfile
+++ b/conda-store-server/Dockerfile
@@ -88,3 +88,21 @@ RUN which python && \
 
 WORKDIR /var/lib/conda-store
 # ---------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------
+# sometimes we need to install the conda-store-server in editable mode with a
+# local bundle of the UI
+FROM base AS ui-dev
+
+ARG UI_PATH=./conda_store_server/_internal/server/static/conda-store-ui
+ENV LOCAL_UI=${UI_PATH}
+
+WORKDIR /opt/conda-store-server
+
+COPY ${UI_PATH}/ /opt/conda-store-server/conda_store_server/UI/dist
+
+RUN which python && \
+    python -m pip install -e . --no-cache-dir
+
+WORKDIR /var/lib/conda-store
+# ---------------------------------------------------------------------------------

--- a/conda-store-server/conda_store_server/_internal/server/templates/conda-store-ui.html
+++ b/conda-store-server/conda_store_server/_internal/server/templates/conda-store-ui.html
@@ -25,6 +25,7 @@ https://conda.store/conda-store-ui/how-tos/configure-ui -->
              REACT_APP_API_URL: "{{ url_for('get_conda_store_ui') }}",
              REACT_APP_LOGIN_PAGE_URL: "{{ url_for('get_login_method') }}?next=",
              REACT_APP_LOGOUT_PAGE_URL: "{{ url_for('post_logout_method') }}?next=/",
+             REACT_APP_URL_BASENAME: "/conda-store",
          };
         </script>
         <script defer src="static/conda-store-ui/main.js"></script>

--- a/docker-compose.ui.yaml
+++ b/docker-compose.ui.yaml
@@ -1,0 +1,31 @@
+services:
+  conda-store-worker:
+    build:
+      context: conda-store-server
+      target: ui-dev
+    extends:
+      file: docker-compose.yaml
+      service: conda-store-worker
+
+  conda-store-server:
+    build:
+        context: conda-store-server
+        target: ui-dev
+    extends:
+      file: docker-compose.yaml
+      service: conda-store-server
+
+  minio:
+    extends:
+      file: docker-compose.yaml
+      service: minio
+
+  postgres:
+    extends:
+      file: docker-compose.yaml
+      service: postgres
+
+  redis:
+    extends:
+      file: docker-compose.yaml
+      service: redis


### PR DESCRIPTION
## Description

There is no issue associated with this PR but this should help us with verifying how we are vendoring the UI (and the conda-store releases)

- [ ] Adds a `docker-compose.ui.yaml` file that builds the `dev-ui` target in the Dockerfile
- [ ] Adds a missing step in our release instructions

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

I will update the docs once someone else verifies this. 

1. You will need to have a local fork of `conda-store-ui` and create a bundle:

	```bash
	yarn run build
	yarn run webpack:prod bundle
	```

2. On the `conda-store` repository:

	```bash
	# change into the conda-store-server dir
	cd conda-store-server

	# build server with the local bundle of the UI
	export LOCAL_UI=<path-to-the-root-of-the-ui-dir>  && hatch build
4. Start the conda-store-instances:


	```bash
	# from the root of the conda-store repo
	docker compose -f docker-compose.ui.yaml up --build
	```

	Head to localhost:8080 when ready, if built against main the version displayed on the UI should be `"2024.9.2-rc1"`
