### PR TITLE
Wait for celery to return response to request to solve specification

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional, TypedDict
 import pydantic
 import yaml
 
+from celery.result import AsyncResult
+
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse, RedirectResponse
 
@@ -844,13 +846,13 @@ async def api_get_specification(
 
         try:
             task, solve_id = conda_store.register_solve(db, specification)
-            task.wait()
+            AsyncResult(task).wait()
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e.args[0]))
 
         solve = api.get_solve(db, solve_id)
 
-        return {"solve": solve.packages}
+        return {"solve": solve.package_builds}
 
 
 @router_api.post(

--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -10,7 +10,6 @@ import pydantic
 import yaml
 
 from celery.result import AsyncResult
-
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse, RedirectResponse
 


### PR DESCRIPTION
Fixes #615 and #761 

## Description

The `GET /specification` endpoint is meant to allow users to specify some conda environment configuration (packages, channels, etc) and return the set of packages for the solved environment.

Previously, this endpoint was broken
```
$ curl http://localhost:5000/conda-store/api/v1/specification/
Internal Server Error
```

With this change, users can use the endpoint 
```
$ curl http://localhost:5000/conda-store/api/v1/specification/
{"solve":[{"id":117414,"channel_id":2,"build_number" .... 

```
 
## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?
