### PR TITLE
[BUG] Pin pyyaml dependency due to cython>=3 incompatibility

### DIFF
--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -59,7 +59,9 @@ dependencies = [
   "pyjwt",
   "psycopg2-binary",
   "pymysql",
-  "pyyaml",
+  # pyyaml>5.3.1 is broken with cython>=3 transitive dependency
+  # See https://github.com/yaml/pyyaml/issues/724 for details
+  "pyyaml==5.3.1",
   "redis",
   "requests",
   "pydantic >=1.10.16,<2.0a0",


### PR DESCRIPTION
Fixes #915.

## Description

This pull request pins `pyyaml==5.3.1` due to an incompatibility with `cython>=3`, which is a transitive dependency of this project.

## Pull request checklist

- [ ] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

@soapy1 Would you be willing to check that this works for you? It's enough to run tests and then `hatch shell dev` inside `conda-store-server/`.