### PR TITLE
Add coverage report to unit tests

### DIFF
--- a/.github/workflows/test_conda_store_server_unit.yaml
+++ b/.github/workflows/test_conda_store_server_unit.yaml
@@ -93,7 +93,11 @@ jobs:
 
       - name: "Unit tests ✅"
         run: |
-          python -m pytest -m "not extended_prefix and not user_journey" tests
+          python -m pytest -m "not extended_prefix and not user_journey" --cov=conda_store_server tests
+
+      - name: "Coverage report"
+        run: |
+          coverage report
 
       # https://github.com/actions/runner-images/issues/1052
       - name: "Windows extended prefix unit tests ✅"

--- a/conda-store-server/environment-dev.yaml
+++ b/conda-store-server/environment-dev.yaml
@@ -22,6 +22,7 @@ dependencies:
   - pytest
   - pytest-celery
   - pytest-mock
+  - pytest-cov
   - docker-py<=7
   - docker-compose
   # build dependencies

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -94,7 +94,7 @@ dependencies = [
   "pytest-playwright",
   "twine>=5.0.0",
   "pkginfo>=1.10", # Needed to support metadata 2.3
-
+  "pytest-cov",
 ]
 
 [tool.hatch.envs.lint]


### PR DESCRIPTION
partially addresses https://github.com/conda-incubator/conda-store/issues/914

## Description

This change addresses the code coverage visibility issue in #914. It enables:
* generating coverage stats when running unit tests
* reporting code coverage results in the github action

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
