### PR TITLE
[MAINT] Update lint tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,6 @@ ci:
     [pre-commit.ci] Apply automatic pre-commit fixes
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
-        exclude: "examples|tests/assets"
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: "v0.6.3"
@@ -26,6 +20,7 @@ repos:
       - id: ruff
         exclude: "examples|tests/assets"
         args: ["--fix"]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -41,11 +36,3 @@ repos:
     hooks:
       - id: prettier
         exclude: ^(examples/|templates/|)
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort
-        args: ["--profile", "black"]
-        exclude: "conda-store-server/conda_store_server/action/__init__.py"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,9 @@ repos:
     hooks:
       - id: ruff
         exclude: "examples|tests/assets"
-        args: ["--fix"]
+        args: ["--fix", "--show-fixes"]
       - id: ruff-format
+        exclude: "examples|tests/assets"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/conda-store-server/conda_store_server/__init__.py
+++ b/conda-store-server/conda_store_server/__init__.py
@@ -1,12 +1,17 @@
 # Copyright (c) conda-store development team. All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
+from __future__ import annotations
 
 import datetime
 import hashlib
 import typing
 
 import platformdirs
+
+if typing.TYPE_CHECKING:
+    from ._internal.orm import Build
+    from .app import CondaStore
 
 
 __version__ = "2024.11.1-dev"
@@ -39,7 +44,7 @@ class BuildKey:
 
     _version3_experimental_hash_size = 32
 
-    def _version1_fmt(build: "Build") -> str:  # noqa: F821
+    def _version1_fmt(build: Build) -> str:  # noqa: F821
         datetime_format = "%Y%m%d-%H%M%S-%f"
         hash = build.specification.sha256
         timestamp = build.scheduled_on.strftime(datetime_format)
@@ -47,7 +52,7 @@ class BuildKey:
         name = build.specification.name
         return f"{hash}-{timestamp}-{id}-{name}"
 
-    def _version2_fmt(build: "Build") -> str:  # noqa: F821
+    def _version2_fmt(build: Build) -> str:  # noqa: F821
         tzinfo = datetime.timezone.utc
         hash = build.specification.sha256[: BuildKey._version2_hash_size]
         timestamp = int(build.scheduled_on.replace(tzinfo=tzinfo).timestamp())
@@ -56,7 +61,7 @@ class BuildKey:
         return f"{hash}-{timestamp}-{id}-{name}"
 
     # Warning: this is an experimental version and can be changed at any time
-    def _version3_experimental_fmt(build: "Build") -> str:  # noqa: F821
+    def _version3_experimental_fmt(build: Build) -> str:  # noqa: F821
         # Caches the hash value for faster lookup later
         if build.hash is not None:
             return build.hash
@@ -113,14 +118,16 @@ class BuildKey:
         return tuple(cls._fmt.keys())
 
     @classmethod
-    def get_build_key(cls, build: "Build") -> str:  # noqa: F821
+    def get_build_key(cls, build: Build) -> str:  # noqa: F821
         """Returns build key for this build"""
         cls._check_version(build.build_key_version)
         return cls._fmt.get(build.build_key_version)(build)
 
     @classmethod
     def parse_build_key(
-        cls, conda_store: "CondaStore", build_key: str  # noqa: F821
+        cls,
+        conda_store: CondaStore,
+        build_key: str,  # noqa: F821
     ) -> int:
         """Returns build id from build key"""
         # This import is here to avoid cyclic imports

--- a/conda-store-server/conda_store_server/_internal/action/download_packages.py
+++ b/conda-store-server/conda_store_server/_internal/action/download_packages.py
@@ -14,7 +14,6 @@ import conda.gateways.logging  # noqa
 import conda_package_handling.api
 import conda_package_streaming.url
 import filelock
-
 from conda.base.constants import PACKAGE_CACHE_MAGIC_FILE
 from conda.common.path import expand, strip_pkg_extension
 from conda.core.package_cache_data import (

--- a/conda-store-server/conda_store_server/_internal/action/generate_constructor_installer.py
+++ b/conda-store-server/conda_store_server/_internal/action/generate_constructor_installer.py
@@ -7,7 +7,6 @@ import pathlib
 import sys
 import tempfile
 import warnings
-
 from typing import Union
 
 import yaml
@@ -54,7 +53,7 @@ def action_generate_constructor_installer(
         warnings.warn(
             "Installer generation requires constructor: https://github.com/conda/constructor"
         )
-        return
+        return None
 
     # pip dependencies are not directly supported by constructor, they will be
     # installed via the post_install script:

--- a/conda-store-server/conda_store_server/_internal/action/generate_lockfile.py
+++ b/conda-store-server/conda_store_server/_internal/action/generate_lockfile.py
@@ -8,7 +8,6 @@ import pathlib
 import typing
 
 import yaml
-
 from conda_lock.conda_lock import run_lock
 
 from conda_store_server._internal import action, conda_utils, schema, utils

--- a/conda-store-server/conda_store_server/_internal/alembic/env.py
+++ b/conda-store-server/conda_store_server/_internal/alembic/env.py
@@ -7,7 +7,6 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config

--- a/conda-store-server/conda_store_server/_internal/build.py
+++ b/conda-store-server/conda_store_server/_internal/build.py
@@ -13,7 +13,6 @@ import traceback
 import typing
 
 import yaml
-
 from filelock import FileLock
 from sqlalchemy.orm import Session
 

--- a/conda-store-server/conda_store_server/_internal/dbutil.py
+++ b/conda-store-server/conda_store_server/_internal/dbutil.py
@@ -4,7 +4,6 @@
 
 import json
 import os
-
 from contextlib import contextmanager
 from functools import partial
 from tempfile import TemporaryDirectory
@@ -14,7 +13,6 @@ from alembic.config import Config
 from sqlalchemy import create_engine, inspect
 
 from conda_store_server._internal import utils
-
 
 _here = os.path.abspath(os.path.dirname(__file__))
 

--- a/conda-store-server/conda_store_server/_internal/environment.py
+++ b/conda-store-server/conda_store_server/_internal/environment.py
@@ -6,7 +6,6 @@ import pathlib
 
 import pydantic
 import yaml
-
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Query
 

--- a/conda-store-server/conda_store_server/_internal/orm.py
+++ b/conda-store-server/conda_store_server/_internal/orm.py
@@ -9,7 +9,6 @@ import os
 import pathlib
 import shutil
 import sys
-
 from functools import partial
 
 from sqlalchemy import (
@@ -41,7 +40,6 @@ from sqlalchemy.orm import (
 
 from conda_store_server._internal import conda_utils, schema, utils
 from conda_store_server._internal.environment import validate_environment
-
 
 logger = logging.getLogger("orm")
 

--- a/conda-store-server/conda_store_server/_internal/schema.py
+++ b/conda-store-server/conda_store_server/_internal/schema.py
@@ -8,7 +8,6 @@ import functools
 import os
 import re
 import sys
-
 from typing import Any, Callable, Dict, List, Optional, TypeAlias, Union
 
 from conda_lock.lockfile.v1.models import Lockfile
@@ -19,7 +18,7 @@ from conda_store_server._internal import conda_utils, utils
 
 
 def _datetime_factory(offset: datetime.timedelta):
-    """utcnow datetime + timezone as string"""
+    """Utcnow datetime + timezone as string"""
     return datetime.datetime.utcnow() + offset
 
 
@@ -41,7 +40,8 @@ RoleBindings: TypeAlias = Dict[constr(regex=ARN_ALLOWED), List[str]]
 
 
 class Permissions(enum.Enum):
-    "Permissions map to conda-store actions"
+    """Permissions map to conda-store actions"""
+
     ENVIRONMENT_CREATE = "environment:create"
     ENVIRONMENT_READ = "environment::read"
     ENVIRONMENT_UPDATE = "environment::update"
@@ -528,7 +528,7 @@ class LockfileSpecification(BaseModel):
 
 
 def _docker_datetime_factory():
-    """utcnow datetime + timezone as string"""
+    """Utcnow datetime + timezone as string"""
     return datetime.datetime.utcnow().astimezone().isoformat()
 
 

--- a/conda-store-server/conda_store_server/_internal/server/__main__.py
+++ b/conda-store-server/conda_store_server/_internal/server/__main__.py
@@ -4,7 +4,6 @@
 
 from conda_store_server._internal.server.app import CondaStoreServer
 
-
 main = CondaStoreServer.launch_instance
 
 if __name__ == "__main__":

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -7,12 +7,10 @@ import os
 import posixpath
 import sys
 import time
-
 from enum import Enum
 from threading import Thread
 
 import uvicorn
-
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
@@ -34,7 +32,6 @@ from traitlets import (
 from traitlets.config import Application, catch_config_error
 
 import conda_store_server
-
 from conda_store_server import __version__, storage
 from conda_store_server._internal import dbutil, orm
 from conda_store_server._internal.server import views
@@ -167,9 +164,7 @@ class CondaStoreServer(Application):
     def _validate_config_file(self, proposal):
         if not os.path.isfile(proposal.value):
             print(
-                "ERROR: Failed to find specified config file: {}".format(
-                    proposal.value
-                ),
+                f"ERROR: Failed to find specified config file: {proposal.value}",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -3,12 +3,10 @@
 # license that can be found in the LICENSE file.
 
 import datetime
-
 from typing import Any, Dict, List, Optional, TypedDict
 
 import pydantic
 import yaml
-
 from celery.result import AsyncResult
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse, RedirectResponse

--- a/conda-store-server/conda_store_server/_internal/server/views/conda_store_ui.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/conda_store_ui.py
@@ -6,7 +6,6 @@ from fastapi import APIRouter, Depends, Request
 
 from conda_store_server.server import dependencies
 
-
 router_conda_store_ui = APIRouter(tags=["conda-store-ui"])
 
 

--- a/conda-store-server/conda_store_server/_internal/server/views/metrics.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/metrics.py
@@ -8,7 +8,6 @@ from fastapi.responses import PlainTextResponse
 from conda_store_server import api
 from conda_store_server.server import dependencies
 
-
 router_metrics = APIRouter(tags=["metrics"])
 
 

--- a/conda-store-server/conda_store_server/_internal/server/views/registry.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/registry.py
@@ -13,7 +13,6 @@ from conda_store_server._internal import orm, schema
 from conda_store_server._internal.schema import Permissions
 from conda_store_server.server import dependencies
 
-
 router_registry = APIRouter(tags=["registry"])
 
 

--- a/conda-store-server/conda_store_server/_internal/server/views/ui.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/ui.py
@@ -5,7 +5,6 @@
 from typing import Optional
 
 import yaml
-
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import RedirectResponse
 
@@ -15,7 +14,6 @@ from conda_store_server._internal.action.generate_constructor_installer import (
 )
 from conda_store_server._internal.schema import Permissions
 from conda_store_server.server import dependencies
-
 
 router_ui = APIRouter(tags=["ui"])
 
@@ -38,7 +36,7 @@ async def ui_create_get_environment(
         )
 
         def sort_namespace(n):
-            "Default namespace always first, then alphabetical"
+            """Default namespace always first, then alphabetical"""
             if n.name == default_namespace:
                 return f"0{n.name}"
             return f"1{n.name}"

--- a/conda-store-server/conda_store_server/_internal/utils.py
+++ b/conda-store-server/conda_store_server/_internal/utils.py
@@ -11,7 +11,6 @@ import re
 import subprocess
 import sys
 import time
-
 from typing import AnyStr
 
 from filelock import FileLock

--- a/conda-store-server/conda_store_server/_internal/worker/__main__.py
+++ b/conda-store-server/conda_store_server/_internal/worker/__main__.py
@@ -4,7 +4,6 @@
 
 from conda_store_server._internal.worker.app import CondaStoreWorker
 
-
 main = CondaStoreWorker.launch_instance
 
 if __name__ == "__main__":

--- a/conda-store-server/conda_store_server/_internal/worker/app.py
+++ b/conda-store-server/conda_store_server/_internal/worker/app.py
@@ -54,9 +54,7 @@ class CondaStoreWorker(Application):
     def _validate_config_file(self, proposal):
         if not os.path.isfile(proposal.value):
             print(
-                "ERROR: Failed to find specified config file: {}".format(
-                    proposal.value
-                ),
+                f"ERROR: Failed to find specified config file: {proposal.value}",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -85,7 +83,6 @@ class CondaStoreWorker(Application):
         return logging_to_celery_level_map[logging_level]
 
     def start(self):
-
         argv = [
             "worker",
             f"--loglevel={self.logger_to_celery_logging_level(self.log_level)}",

--- a/conda-store-server/conda_store_server/_internal/worker/tasks.py
+++ b/conda-store-server/conda_store_server/_internal/worker/tasks.py
@@ -9,7 +9,6 @@ import sys
 import typing
 
 import yaml
-
 from celery import Task, platforms, shared_task
 from celery.execute import send_task
 from celery.signals import worker_ready

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import re
-
 from typing import Any, Dict, List, Union
 
 from sqlalchemy import distinct, func, null, or_
@@ -569,9 +568,7 @@ def get_build_lockfile_legacy(db, build_id: int):
     return """#platform: {0}
 @EXPLICIT
 {1}
-""".format(
-        conda_utils.conda_platform(), "\n".join(packages)
-    )
+""".format(conda_utils.conda_platform(), "\n".join(packages))
 
 
 def get_build_artifact_types(db, build_id: int):

--- a/conda-store-server/conda_store_server/app.py
+++ b/conda-store-server/conda_store_server/app.py
@@ -5,12 +5,10 @@
 import datetime
 import os
 import sys
-
 from contextlib import contextmanager
 from typing import Any, Dict
 
 import pydantic
-
 from celery import Celery, group
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
@@ -624,7 +622,6 @@ class CondaStore(LoggingConfigurable):
         is_lockfile: bool = False,
     ):
         """Register a given specification to conda store with given namespace/name."""
-
         settings = self.get_settings(db)
 
         namespace = namespace or settings.default_namespace

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -6,14 +6,12 @@ import base64
 import datetime
 import re
 import secrets
-
 from collections import defaultdict
 from typing import Iterable, Optional, Set
 
 import jwt
 import requests
 import yarl
-
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse

--- a/conda-store-server/conda_store_server/storage.py
+++ b/conda-store-server/conda_store_server/storage.py
@@ -8,7 +8,6 @@ import posixpath
 import shutil
 
 import minio
-
 from minio.credentials.providers import Provider
 from traitlets import Bool, Dict, List, Type, Unicode
 from traitlets.config import LoggingConfigurable

--- a/conda-store-server/hatch_build.py
+++ b/conda-store-server/hatch_build.py
@@ -14,12 +14,10 @@ import shutil
 import tarfile
 import tempfile
 import urllib.request
-
 from pathlib import Path
 from typing import Any, Dict, List
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
-
 
 CONDA_STORE_UI_VERSION = "2024.10.1"
 CONDA_STORE_UI_URL = f"https://registry.npmjs.org/@conda-store/conda-store-ui/-/conda-store-ui-{CONDA_STORE_UI_VERSION}.tgz"
@@ -89,7 +87,6 @@ class DownloadCondaStoreUIHook(BuildHookInterface):
             ui_version (str): conda-store-ui version to download, must be a
             valid npm release
         """
-
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             tmp_filename = tmp_dir / "conda-store-ui.tgz"
@@ -114,7 +111,6 @@ class DownloadCondaStoreUIHook(BuildHookInterface):
         Args:
             source_directory (str): path to the directory containing the UI files
         """
-
         server_build_static_assets = Path(self.root) / SERVER_UI_ASSETS
         server_build_static_assets.mkdir(parents=True, exist_ok=True)
 
@@ -133,6 +129,6 @@ class DownloadCondaStoreUIHook(BuildHookInterface):
                 f"Copied files: {[p.name for p in server_build_static_assets.glob('*')]}"
             )
 
-        except (IOError, OSError) as e:
+        except OSError as e:
             print(f"Error copying files: {e}")
             raise

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -130,12 +130,108 @@ lines_after_imports = 2
 
 [tool.ruff]
 line-length = 88
+exclude = [
+    "conda_store_server/_internal/alembic/versions/"
+]
 
 [tool.ruff.lint]
 ignore = [
-  "E501", # line-length
+    "E501", # line-length
 
+    "ANN001",	# missing-type-function-argument
+    "ANN002",	# missing-type-args
+    "ANN003",	# missing-type-kwargs
+    "ANN101",	# missing-type-self
+    "ANN102",	# missing-type-cls
+    "ANN201",	# missing-return-type-undocumented-public-function
+    "ANN202",	# missing-return-type-private-function
+    "ANN204",	# missing-return-type-special-method
+    "ANN205",	# missing-return-type-static-method
+    "ANN206",	# missing-return-type-class-method
+    "ARG001",	# unused-function-argument
+    "ARG002",	# unused-method-argument
+    "B006",  	# mutable-argument-default
+    "B007",  	# unused-loop-control-variable
+    "B008",  	# function-call-in-default-argument
+    "B011",  	# assert-false
+    "B015",  	# useless-comparison
+    "B017",  	# assert-raises-exception
+    "B018",  	# useless-expression
+    "B028",  	# no-explicit-stacklevel
+    "B904",  	# raise-without-from-inside-except
+    "D100",  	# undocumented-public-module
+    "D101",  	# undocumented-public-class
+    "D102",  	# undocumented-public-method
+    "D103",  	# undocumented-public-function
+    "D104",  	# undocumented-public-package
+    "D200",  	# fits-on-one-line
+    "D205",  	# blank-line-after-summary
+    "D400",  	# ends-in-period
+    "D401",  	# non-imperative-mood
+    "D404",  	# docstring-starts-with-this
+    "ERA001",	# commented-out-code
+    "FIX001",	# line-contains-fixme
+    "FIX002",	# line-contains-todo
+    "N805",  	# invalid-first-argument-name-for-method
+    "N815",  	# mixed-case-variable-in-class-scope
+    "PT004", 	# pytest-missing-fixture-name-underscore
+    "PT006", 	# pytest-parametrize-names-wrong-type
+    "PT011", 	# pytest-raises-too-broad
+    "PT012", 	# pytest-raises-with-multiple-statements
+    "PT014", 	# pytest-duplicate-parametrize-test-cases
+    "PT015", 	# pytest-assert-always-false
+    "RET503",	# implicit-return
+    "RET504",	# unnecessary-assign
+    "RET505",	# superfluous-else-return
+    "RET506",	# superfluous-else-raise
+    "SIM105",	# suppressible-exception
+    "SIM115",	# open-file-with-context-handler
+    "SIM117",	# multiple-with-statements
+    "UP006", 	# non-pep585-annotation
+    "UP007", 	# non-pep604-annotation
+    "UP030", 	# format-literals
+    "UP031", 	# printf-string-formatting
 ]
+select = [
+    # pycodestyle
+    "E",
+    "W",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    # pep8 naming
+    "N",
+    # pydocstyle
+    "D",
+    # annotations
+    "ANN",
+    # debugger
+    "T10",
+    # flake8-pytest
+    "PT",
+    # flake8-return
+    "RET",
+    # flake8-unused-arguments
+    "ARG",
+    # flake8-fixme
+    "FIX",
+    # flake8-eradicate
+    "ERA",
+    # pandas-vet
+    "PD",
+    # numpy-specific rules
+    "NPY",
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.check-wheel-contents]
 # ignore alembic migrations https://github.com/jwodder/check-wheel-contents?tab=readme-ov-file#w004--module-is-not-located-at-importable-path

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -127,6 +127,7 @@ line-length = 88
 [tool.isort]
 lines_between_types = 1
 lines_after_imports = 2
+profile = 'black'
 
 [tool.ruff]
 line-length = 88
@@ -193,41 +194,24 @@ ignore = [
     "UP031", 	# printf-string-formatting
 ]
 select = [
-    # pycodestyle
-    "E",
-    "W",
-    # Pyflakes
-    "F",
-    # pyupgrade
-    "UP",
-    # flake8-bugbear
-    "B",
-    # flake8-simplify
-    "SIM",
-    # isort
-    "I",
-    # pep8 naming
-    "N",
-    # pydocstyle
-    "D",
-    # annotations
-    "ANN",
-    # debugger
-    "T10",
-    # flake8-pytest
-    "PT",
-    # flake8-return
-    "RET",
-    # flake8-unused-arguments
-    "ARG",
-    # flake8-fixme
-    "FIX",
-    # flake8-eradicate
-    "ERA",
-    # pandas-vet
-    "PD",
-    # numpy-specific rules
-    "NPY",
+    "E",   # pycodestyle
+    "W",   # pycodestyle
+    "F",   # Pyflakes
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "SIM", # flake8-simplify
+    "I",   # isort
+    "N",   # pep8 naming
+    "D",   # pydocstyle
+    "ANN", # annotations
+    "T10", # debugger
+    "PT",  # flake8-pytest
+    "RET", # flake8-return
+    "ARG", # flake8-unused-arguments
+    "FIX", # flake8-fixme
+    "ERA", # flake8-eradicate
+    "PD",  # pandas-vet
+    "NPY", # numpy-specific rules
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/conda-store-server/tests/_internal/action/test_actions.py
+++ b/conda-store-server/tests/_internal/action/test_actions.py
@@ -8,13 +8,11 @@ import pathlib
 import re
 import sys
 import tempfile
-
 from unittest import mock
 
 import pytest
 import yaml
 import yarl
-
 from celery.result import AsyncResult
 from conda.base.context import context as conda_base_context
 from constructor import construct

--- a/conda-store-server/tests/_internal/server/views/test_api.py
+++ b/conda-store-server/tests/_internal/server/views/test_api.py
@@ -11,7 +11,6 @@ import time
 import pytest
 import traitlets
 import yaml
-
 from fastapi.testclient import TestClient
 
 from conda_store_server import CONDA_STORE_DIR, __version__
@@ -1047,7 +1046,8 @@ def test_put_global_settings_auth_in_namespace_environment(
     testclient, authenticate, route
 ):
     """This is a test that you cannot set a global setting at the
-    namespace or environment settings level"""
+    namespace or environment settings level
+    """
     response = testclient.put(
         route,
         json={

--- a/conda-store-server/tests/_internal/test_utils.py
+++ b/conda-store-server/tests/_internal/test_utils.py
@@ -4,7 +4,6 @@
 
 from conda_store_server._internal.utils import disk_usage, du
 
-
 # TODO: Add tests for the other functions in utils.py
 
 

--- a/conda-store-server/tests/_internal/worker/test_app.py
+++ b/conda-store-server/tests/_internal/worker/test_app.py
@@ -4,11 +4,9 @@
 
 import logging
 import sys
-
 from unittest.mock import patch
 
 import pytest
-
 from traitlets.config import Config
 
 from conda_store_server._internal.worker.app import CondaStoreWorker

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -11,12 +11,10 @@ import uuid
 
 import pytest
 import yaml
-
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from conda_store_server import api, app, storage
-
 
 from conda_store_server._internal import (  # isort:skip
     action,
@@ -105,7 +103,7 @@ def conda_store_server(conda_store_config):
 
         ResultModelBase.metadata.create_all(db.get_bind())
 
-    yield _conda_store_server
+    return _conda_store_server
 
 
 @pytest.fixture
@@ -162,7 +160,7 @@ def seed_conda_store(db, conda_store):
     build.ended_on = datetime.datetime.utcnow()
     build.status = schema.BuildStatus.COMPLETED
     db.commit()
-    yield db
+    return db
 
 
 @pytest.fixture
@@ -189,7 +187,7 @@ def conda_store(conda_store_config):
 
         ResultModelBase.metadata.create_all(db.get_bind())
 
-    yield _conda_store
+    return _conda_store
 
 
 @pytest.fixture
@@ -200,7 +198,7 @@ def db(conda_store):
 
 @pytest.fixture
 def simple_specification():
-    yield schema.CondaSpecification(
+    return schema.CondaSpecification(
         name="test",
         channels=["main"],
         dependencies=["zlib"],
@@ -209,7 +207,7 @@ def simple_specification():
 
 @pytest.fixture
 def simple_specification_with_pip():
-    yield schema.CondaSpecification(
+    return schema.CondaSpecification(
         name="test",
         channels=["main"],
         dependencies=[
@@ -235,7 +233,7 @@ def simple_conda_lock_with_pip():
 
 @pytest.fixture
 def simple_lockfile_specification(simple_conda_lock):
-    yield schema.LockfileSpecification.parse_obj(
+    return schema.LockfileSpecification.parse_obj(
         {
             "name": "test",
             "description": "simple lockfile specification",
@@ -246,7 +244,7 @@ def simple_lockfile_specification(simple_conda_lock):
 
 @pytest.fixture
 def simple_lockfile_specification_with_pip(simple_conda_lock_with_pip):
-    yield schema.LockfileSpecification.parse_obj(
+    return schema.LockfileSpecification.parse_obj(
         {
             "name": "test",
             "description": "simple lockfile specification with pip",
@@ -280,7 +278,7 @@ def conda_prefix(conda_store, tmp_path, request):
         specification=specification,
         conda_prefix=conda_prefix,
     )
-    yield conda_prefix
+    return conda_prefix
 
 
 def _seed_conda_store(

--- a/conda-store-server/tests/test_api.py
+++ b/conda-store-server/tests/test_api.py
@@ -3,7 +3,6 @@
 # license that can be found in the LICENSE file.
 
 import pytest
-
 from sqlalchemy.exc import IntegrityError
 
 from conda_store_server import api
@@ -11,7 +10,7 @@ from conda_store_server._internal.orm import NamespaceRoleMapping
 from conda_store_server._internal.utils import BuildPathError
 
 
-@pytest.fixture()
+@pytest.fixture
 def populated_db(db):
     """A database fixture populated with 4 envs in 3 namespaces."""
     description = "Hello World"
@@ -352,11 +351,11 @@ def test_get_set_keyvaluestore(db):
 
     # test updating a prefix
     api.set_kvstore_key_values(db, "pytest", setting_2)
-    assert {**setting_1, **setting_2} == api.get_kvstore_key_values(db, "pytest")
+    assert api.get_kvstore_key_values(db, "pytest") == {**setting_1, **setting_2}
 
     # test updating a prefix
     api.set_kvstore_key_values(db, "pytest", {"c": 999, "d": 999}, update=False)
-    assert {**setting_1, **setting_2} == api.get_kvstore_key_values(db, "pytest")
+    assert api.get_kvstore_key_values(db, "pytest") == {**setting_1, **setting_2}
 
 
 def test_build_path_too_long(db, conda_store, simple_specification):

--- a/conda-store-server/tests/test_app.py
+++ b/conda-store-server/tests/test_app.py
@@ -5,7 +5,6 @@
 import sys
 
 import pytest
-
 from celery.result import AsyncResult
 
 from conda_store_server import api

--- a/conda-store-server/tests/test_storage.py
+++ b/conda-store-server/tests/test_storage.py
@@ -6,7 +6,7 @@ from conda_store_server import api, storage
 from conda_store_server._internal import schema
 
 
-@pytest.fixture()
+@pytest.fixture
 def local_file_store(tmp_path):
     """Setup a tmp dir with 2 test files and a logs dir"""
     tf_one = str(tmp_path / "testfile1")
@@ -20,7 +20,7 @@ def local_file_store(tmp_path):
     logs_path = tmp_path / "logs"
     os.mkdir(logs_path)
 
-    yield tmp_path
+    return tmp_path
 
 
 class TestStorage:
@@ -68,7 +68,7 @@ class TestLocalStorage:
 
         target_file = str(local_file_store / "new_build_key")
         assert os.path.exists(target_file)
-        target_content = open(target_file, "r").read()
+        target_content = open(target_file).read()
         assert target_content == "testfile1"
 
     def test_fset_dont_overwrite_file(self, db, local_file_store):
@@ -83,7 +83,7 @@ class TestLocalStorage:
 
         target_file = str(local_file_store / "testfile2")
         assert os.path.exists(target_file)
-        target_content = open(target_file, "r").read()
+        target_content = open(target_file).read()
         assert target_content == "testfile1"
 
     def test_set_new_package(self, db, local_file_store):
@@ -102,7 +102,7 @@ class TestLocalStorage:
 
         target_file = str(local_file_store / "new_build_key")
         assert os.path.exists(target_file)
-        target_content = open(target_file, "r").read()
+        target_content = open(target_file).read()
         assert target_content == "somestuff"
 
     def test_get(self, local_file_store):

--- a/conda-store-server/tests/test_traitlets.py
+++ b/conda-store-server/tests/test_traitlets.py
@@ -6,7 +6,6 @@ import pathlib
 import tempfile
 
 import pytest
-
 from fastapi.templating import Jinja2Templates
 from fastapi.testclient import TestClient
 

--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -61,9 +61,7 @@ def test_admin_login_and_delete_shared_environment(
     environment = api.create_environment(
         namespace,
         specification_path,
-    ).json()["data"][
-        "specification"
-    ]["name"]
+    ).json()["data"]["specification"]["name"]
 
     api.delete_environment(namespace, environment)
     api.delete_namespace(namespace)
@@ -91,17 +89,13 @@ def test_user_login_and_create_shared_environment(
         token=api.create_token(
             namespace,
             "developer",
-        ).json()[
-            "data"
-        ]["token"],
+        ).json()["data"]["token"],
     )
 
     environment = dev_api.create_environment(
         namespace,
         specification_path,
-    ).json()[
-        "data"
-    ]["specification"]["name"]
+    ).json()["data"]["specification"]["name"]
 
     api.delete_environment(namespace, environment)
     api.delete_namespace(namespace)
@@ -139,9 +133,7 @@ def test_admin_set_active_build(base_url: str):
     assert api.get_environment(
         namespace=namespace,
         environment=environment,
-    )[
-        "current_build_id"
-    ] == max(build_ids)
+    )["current_build_id"] == max(build_ids)
 
     api.set_active_build(
         namespace=namespace, environment=environment, build_id=min(build_ids)
@@ -150,9 +142,7 @@ def test_admin_set_active_build(base_url: str):
     assert api.get_environment(
         namespace=namespace,
         environment=environment,
-    )[
-        "current_build_id"
-    ] == min(build_ids)
+    )["current_build_id"] == min(build_ids)
 
     for env in envs:
         api.delete_environment(namespace, env)

--- a/conda-store-server/tests/user_journeys/utils/api_utils.py
+++ b/conda-store-server/tests/user_journeys/utils/api_utils.py
@@ -7,13 +7,12 @@
 import json
 import time
 import uuid
-
 from enum import Enum
 from typing import Any, Callable, Dict, Optional, Union
 
 import requests
-import utils.time_utils as time_utils
 
+import utils.time_utils as time_utils
 
 TIMEOUT = 10
 
@@ -160,7 +159,7 @@ class API:
             Response from the conda-store server's api/v1/build/{build_id}/
             endpoint
         """
-        with open(specification_path, "r", encoding="utf-8") as file:
+        with open(specification_path, encoding="utf-8") as file:
             specification_content = file.read()
 
         response = self._make_request(


### PR DESCRIPTION
Closes #934.

## Description

This PR implements a couple of improvements to the lint system.

- `black` has been swapped out for the more performant `ruff format`
- `isort` has been removed in favor of enabling ruff's isort ruleset
- A few other rulesets have been enabled as well. However, due to existing violations, a number of individual rules have been disabled until we can fix them one by one.

The main changes were:

- `.pre-commit-config.yaml` has been updated to use `ruff` and `ruff format`
- `conda-store-server/pyproject.toml` has a list of updated rules (and ignores, which were added because of existing rule violations in code. These will be fixed in followup PRs). I've also formally made the docstring style numpydoc in the pydocstyle configuration; most of the (well formatted) docstrings in the code follow numpydoc anyway.
- Fixed some type annotations in `conda_store_server/__init__.py`; needed to add `from __future__ import annotations` to make this work for python<3.11
- The rest of the changes are considered "safe" changes introduced by `ruff --fix`.

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?