### PR TITLE
Make conda-store server launch uvicorn with log level

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -451,7 +451,7 @@ class CondaStoreServer(Application):
                     else []
                 ),
                 factory=True,
-                log_level=self.log_level
+                log_level=self.log_level,
             )
 
         except:

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -451,6 +451,7 @@ class CondaStoreServer(Application):
                     else []
                 ),
                 factory=True,
+                log_level=self.log_level
             )
 
         except:


### PR DESCRIPTION
Fixes # https://github.com/conda-incubator/conda-store/issues/516
(along with https://github.com/conda-incubator/conda-store/pull/903)

## Description

This change ensures that the log level set by the `CondaStoreServer.log_level` config gets applied to the uvicorn server. The default behaviour remains the same, that is, the log level is set to `INFO` by default ([this is the default by uvicorn ](https://www.uvicorn.org/settings/#logging)when the log_level is not set).

To test this out, try running a conda-store server with the following configs:

See info level logging (currently, the only option)
```
c.CondaStoreServer.log_level = logging.INFO
```

See critical level logging (pretty much no logs output)
```
c.CondaStoreServer.log_level = logging.CRITICAL
```

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

