### PR TITLE
Bump k8 example version

### DIFF
--- a/docusaurus-docs/conda-store/how-tos/install-kubernetes.md
+++ b/docusaurus-docs/conda-store/how-tos/install-kubernetes.md
@@ -51,6 +51,12 @@ kubectl port-forward service/conda-store-server 8080:8080
 
 Then visit via your web browser [http://localhost:8080](http://localhost:8080)
 
+To enable viewing logs, make sure to also port forward the minio service
+
+```shell
+kubectl port-forward  service/minio 30900:9000
+```
+
 For additional configuration options see the [reference guide](../references/configuration-options.md)
 
 A good test that conda-store is functioning properly is to apply the

--- a/examples/kubernetes/conda-store-server.yaml
+++ b/examples/kubernetes/conda-store-server.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: conda-store-server
-          image: quansight/conda-store-server:v0.4.5
+          image: quansight/conda-store-server:2024.10.1
           args:
             - "conda-store-server"
             - "--config"

--- a/examples/kubernetes/conda-store-worker.yaml
+++ b/examples/kubernetes/conda-store-worker.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: conda-store-server
-          image: quansight/conda-store-server:v0.4.5
+          image: quansight/conda-store-server:2024.10.1
           args:
             - "conda-store-worker"
             - "--config"


### PR DESCRIPTION
## Description

Currently, the k8's example is running an outdated version of conda store. To provide a more current/relevant setup, update the container images to the latest release `2024.10.1`

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
