### PR TITLE
Update conda-package-build causes an integrity error on conda_package_build table

### DIFF
--- a/conda-store-server/conda_store_server/_internal/orm.py
+++ b/conda-store-server/conda_store_server/_internal/orm.py
@@ -653,6 +653,7 @@ class CondaChannel(Base):
                         and_(
                             CondaPackage.name == p_name,
                             CondaPackage.version == p_version,
+                            CondaPackage.channel_id == self.id,
                         )
                     )
                 all_parent_packages = (
@@ -720,7 +721,7 @@ class CondaPackage(Base):
     description = Column(Text, nullable=True)
 
     def __repr__(self):
-        return f"<CondaPackage (channel={self.channel} name={self.name} version={self.version})>"
+        return f"<CondaPackage (channel={self.channel_id} name={self.name} version={self.version})>"
 
 
 class CondaPackageBuild(Base):

--- a/conda-store-server/tests/_internal/test_orm.py
+++ b/conda-store-server/tests/_internal/test_orm.py
@@ -12,10 +12,10 @@ from conda_store_server._internal import orm
 
 @pytest.fixture
 def populated_db(db):
-    """A database fixture populated with 
-        * 2 channels
-        * 2 conda packages
-        * 3 conda package builds
+    """A database fixture populated with
+    * 2 channels
+    * 2 conda packages
+    * 3 conda package builds
     """
     # create test channels
     api.create_conda_channel(db, "test-channel-1")
@@ -105,6 +105,7 @@ def populated_db(db):
 
     return db
 
+
 @pytest.fixture
 def test_repodata():
     """Basic repodata for linux-64 subdir with 1 package"""
@@ -129,6 +130,7 @@ def test_repodata():
             },
         }
     }
+
 
 @pytest.fixture
 def test_repodata_multiple_packages():
@@ -188,7 +190,9 @@ def test_update_packages_first_time(mock_repdata, db, test_repodata):
 
 
 @mock.patch("conda_store_server._internal.conda_utils.download_repodata")
-def test_update_packages_add_existing_pkg_new_version(mock_repdata, populated_db, test_repodata):
+def test_update_packages_add_existing_pkg_new_version(
+    mock_repdata, populated_db, test_repodata
+):
     # mock download_repodata to return static test repodata
     mock_repdata.return_value = test_repodata
 
@@ -380,7 +384,9 @@ def test_update_packages_new_package_channel(mock_repdata, populated_db, test_re
 
 
 @mock.patch("conda_store_server._internal.conda_utils.download_repodata")
-def test_update_packages_multiple_builds(mock_repdata, populated_db, test_repodata_multiple_packages):
+def test_update_packages_multiple_builds(
+    mock_repdata, populated_db, test_repodata_multiple_packages
+):
     # mock download_repodata to return static test repodata
     mock_repdata.return_value = test_repodata_multiple_packages
 
@@ -410,7 +416,9 @@ def test_update_packages_multiple_builds(mock_repdata, populated_db, test_repoda
 
 
 @mock.patch("conda_store_server._internal.conda_utils.download_repodata")
-def test_update_packages_channel_consistency(mock_repdata, populated_db, test_repodata_multiple_packages):
+def test_update_packages_channel_consistency(
+    mock_repdata, populated_db, test_repodata_multiple_packages
+):
     mock_repdata.return_value = test_repodata_multiple_packages
 
     channel = (

--- a/conda-store-server/tests/_internal/test_orm.py
+++ b/conda-store-server/tests/_internal/test_orm.py
@@ -1,0 +1,445 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from unittest import mock
+
+import pytest
+
+from conda_store_server import api
+from conda_store_server._internal import orm
+
+
+@pytest.fixture
+def populated_db(db):
+    """A database fixture populated with 
+        * 2 channels
+        * 2 conda packages
+        * 3 conda package builds
+    """
+    # create test channels
+    api.create_conda_channel(db, "test-channel-1")
+    api.create_conda_channel(db, "test-channel-2")
+    db.commit()
+
+    # create some sample conda_package's
+    conda_package_records = [
+        {
+            "channel_id": 1,
+            "name": "test-package-1",
+            "version": "1.0.0",
+            "license": "",
+            "license_family": "",
+            "summary": "",
+            "description": "",
+        },
+        {
+            "channel_id": 2,
+            "name": "test-package-1",
+            "version": "1.0.0",
+            "license": "",
+            "license_family": "",
+            "summary": "",
+            "description": "",
+        },
+    ]
+    for conda_package_record in conda_package_records:
+        api.create_conda_package(db, conda_package_record)
+    db.commit()
+
+    # create some conda_package_build's
+    conda_package_builds = [
+        (
+            1,
+            {
+                "build": "py310h06a4308_0",
+                "channel_id": 1,
+                "build_number": 0,
+                "sha256": "11f080b53b36c056dbd86ccd6dc56c40e3e70359f64279b1658bb69f91ae726f",
+                "subdir": "linux-64",
+                "constrains": "",
+                "md5": "",
+                "depends": "",
+                "timestamp": "",
+                "size": "",
+            },
+        ),
+        (
+            1,
+            {
+                "build": "py311h06a4308_0",
+                "channel_id": 1,
+                "build_number": 0,
+                "sha256": "f0719ee6940402a1ea586921acfaf752fda977dbbba74407856a71ba7f6c4e4a",
+                "subdir": "linux-64",
+                "constrains": "",
+                "md5": "",
+                "depends": "",
+                "timestamp": "",
+                "size": "",
+            },
+        ),
+        (
+            1,
+            {
+                "build": "py38h06a4308_0",
+                "channel_id": 1,
+                "build_number": 0,
+                "sha256": "39e39a23baebd0598c1b59ae0e82b5ffd6a3230325da4c331231d55cbcf13b3e",
+                "subdir": "linux-64",
+                "constrains": "",
+                "md5": "",
+                "depends": "",
+                "timestamp": "",
+                "size": "",
+            },
+        ),
+    ]
+    for cpb in conda_package_builds:
+        conda_package_build = orm.CondaPackageBuild(
+            package_id=cpb[0],
+            **cpb[1],
+        )
+        db.add(conda_package_build)
+    db.commit()
+
+    return db
+
+@pytest.fixture
+def test_repodata():
+    """Basic repodata for linux-64 subdir with 1 package"""
+    return {
+        "architectures": {
+            "linux-64": {
+                "packages": {
+                    "test-package-1-0.1.0-py310_0.tar.bz2": {
+                        "build": "py37_0",
+                        "build_number": 0,
+                        "depends": ["some-depends"],
+                        "license": "BSD",
+                        "md5": "a75683f8d9f5b58c19a8ec5d0b7f796e",
+                        "name": "test-package-1",
+                        "sha256": "1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a2630a9fe5810f",
+                        "size": 3832,
+                        "subdir": "linux-64",
+                        "timestamp": 1530731681870,
+                        "version": "0.1.0",
+                    },
+                }
+            },
+        }
+    }
+
+@pytest.fixture
+def test_repodata_multiple_packages():
+    """Basic repodata for linux-64 subdir with 2 builds for the same package"""
+    return {
+        "architectures": {
+            "linux-64": {
+                "packages": {
+                    "test-package-1-1.0.0-py310_0.tar.bz2": {
+                        "build": "py310_0",
+                        "build_number": 0,
+                        "depends": ["some-depends"],
+                        "license": "BSD",
+                        "md5": "a75683f8d9f5b58c19a8ec5d0b7f796e",
+                        "name": "test-package-1",
+                        "sha256": "1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a26something",
+                        "size": 3832,
+                        "subdir": "linux-64",
+                        "timestamp": 1530731681870,
+                        "version": "1.0.0",
+                    },
+                    "test-package-1-1.0.0-py37_0.tar.bz2": {
+                        "build": "py37_0",
+                        "build_number": 0,
+                        "depends": ["some-depends"],
+                        "license": "BSD",
+                        "md5": "a75683f8d9f5b58c19a8ec5d0b7f796e",
+                        "name": "test-package-1",
+                        "sha256": "1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a26else",
+                        "size": 3832,
+                        "subdir": "linux-64",
+                        "timestamp": 1530731681870,
+                        "version": "1.0.0",
+                    },
+                }
+            }
+        }
+    }
+
+
+@mock.patch("conda_store_server._internal.conda_utils.download_repodata")
+def test_update_packages_first_time(mock_repdata, db, test_repodata):
+    # mock download_repodata to return static test repodata
+    mock_repdata.return_value = test_repodata
+
+    # create test channel
+    channel = api.create_conda_channel(db, "test-channel-1")
+
+    channel.update_packages(db, "linux-64")
+
+    # ensure the package is added
+    conda_packages = db.query(orm.CondaPackage).all()
+    assert len(conda_packages) == 1
+
+    conda_packages = db.query(orm.CondaPackageBuild).all()
+    assert len(conda_packages) == 1
+
+
+@mock.patch("conda_store_server._internal.conda_utils.download_repodata")
+def test_update_packages_add_existing_pkg_new_version(mock_repdata, populated_db, test_repodata):
+    # mock download_repodata to return static test repodata
+    mock_repdata.return_value = test_repodata
+
+    # check state of db before updating packages
+    count = (
+        populated_db.query(orm.CondaPackage)
+        .filter(orm.CondaPackage.channel_id == 1)
+        .count()
+    )
+    assert count == 1
+    count = populated_db.query(orm.CondaPackage).count()
+    assert count == 2
+
+    channel = (
+        populated_db.query(orm.CondaChannel).filter(orm.CondaChannel.id == 1).first()
+    )
+    channel.update_packages(populated_db, "linux-64")
+
+    # ensure the package is added
+    count = (
+        populated_db.query(orm.CondaPackage)
+        .filter(orm.CondaPackage.channel_id == 1)
+        .count()
+    )
+    assert count == 2
+    count = populated_db.query(orm.CondaPackage).count()
+    assert count == 3
+    builds = (
+        populated_db.query(orm.CondaPackageBuild)
+        .filter(orm.CondaPackageBuild.channel_id == 1)
+        .all()
+    )
+    assert len(builds) == 4
+    for b in builds:
+        assert b.package.channel_id == 1
+    count = populated_db.query(orm.CondaPackageBuild).count()
+    assert count == 4
+
+
+@mock.patch("conda_store_server._internal.conda_utils.download_repodata")
+def test_update_packages_multiple_subdirs(mock_repdata, populated_db):
+    # mock download_repodata to return static test repodata
+    repodata = {
+        "architectures": {
+            "win-64": {
+                "packages": {
+                    "_libgcc_mutex-1.0.0-py310_0.tar.bz2": {
+                        "build": "py37_0",
+                        "build_number": 0,
+                        "depends": ["some-depends"],
+                        "license": "BSD",
+                        "md5": "a75683f8d9f5b58c19a8ec5d0b7f3sg5",
+                        "name": "_libgcc_mutex",
+                        "sha256": "1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a2630a9fe123s",
+                        "size": 3832,
+                        "subdir": "win-64",
+                        "timestamp": 1530731681870,
+                        "version": "1.0.0",
+                    },
+                },
+            },
+            "linux-64": {
+                "packages": {
+                    "_libgcc_mutex-1.0.0-py310_0.tar.bz2": {
+                        "build": "py37_0",
+                        "build_number": 0,
+                        "depends": ["some-depends"],
+                        "license": "BSD",
+                        "md5": "a75683f8d9f5b58c19a8ec5d0b7f796e",
+                        "name": "_libgcc_mutex",
+                        "sha256": "1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a2630a9fe5810f",
+                        "size": 3832,
+                        "subdir": "linux-64",
+                        "timestamp": 1530731681870,
+                        "version": "1.0.0",
+                    },
+                }
+            },
+        }
+    }
+    mock_repdata.return_value = repodata
+
+    # check state of db before updating packages
+    count = (
+        populated_db.query(orm.CondaPackage)
+        .filter(orm.CondaPackage.channel_id == 1)
+        .count()
+    )
+    assert count == 1
+
+    channel = (
+        populated_db.query(orm.CondaChannel).filter(orm.CondaChannel.id == 1).first()
+    )
+    channel.update_packages(populated_db)
+
+    # ensure the packages are added
+    count = (
+        populated_db.query(orm.CondaPackage)
+        .filter(orm.CondaPackage.channel_id == 1)
+        .count()
+    )
+    assert count == 2
+    builds = (
+        populated_db.query(orm.CondaPackageBuild)
+        .filter(orm.CondaPackageBuild.channel_id == 1)
+        .all()
+    )
+    assert len(builds) == 5
+    for b in builds:
+        assert b.package.channel_id == 1
+
+
+@mock.patch("conda_store_server._internal.conda_utils.download_repodata")
+def test_update_packages_twice(mock_repdata, populated_db, test_repodata):
+    # mock download_repodata to return static test repodata
+    mock_repdata.return_value = test_repodata
+
+    def check_packages():
+        # ensure package is added
+        conda_packages = (
+            populated_db.query(orm.CondaPackage)
+            .filter(orm.CondaPackage.channel_id == 1)
+            .all()
+        )
+        assert len(conda_packages) == 2
+        conda_packages = (
+            populated_db.query(orm.CondaPackage)
+            .filter(orm.CondaPackage.channel_id == 2)
+            .all()
+        )
+        assert len(conda_packages) == 1
+        conda_packages = (
+            populated_db.query(orm.CondaPackageBuild)
+            .filter(orm.CondaPackageBuild.channel_id == 1)
+            .all()
+        )
+        assert len(conda_packages) == 4
+        conda_packages = (
+            populated_db.query(orm.CondaPackageBuild)
+            .filter(orm.CondaPackageBuild.channel_id == 2)
+            .all()
+        )
+        assert len(conda_packages) == 0
+
+    channel = (
+        populated_db.query(orm.CondaChannel).filter(orm.CondaChannel.id == 1).first()
+    )
+
+    # run update
+    channel.update_packages(populated_db, "linux-64")
+
+    # check packages
+    check_packages()
+
+    # run update again
+    channel.update_packages(populated_db, "linux-64")
+
+    # ensure packages stay the same
+    check_packages
+
+
+@mock.patch("conda_store_server._internal.conda_utils.download_repodata")
+def test_update_packages_new_package_channel(mock_repdata, populated_db, test_repodata):
+    # mock download_repodata to return static test repodata
+    mock_repdata.return_value = test_repodata
+
+    channel = (
+        populated_db.query(orm.CondaChannel).filter(orm.CondaChannel.id == 2).first()
+    )
+    channel.update_packages(populated_db, "linux-64")
+
+    # ensure the package is added
+    count = (
+        populated_db.query(orm.CondaPackage)
+        .filter(orm.CondaPackage.channel_id == 2)
+        .count()
+    )
+    assert count == 2
+    builds = (
+        populated_db.query(orm.CondaPackageBuild)
+        .filter(orm.CondaPackageBuild.channel_id == 2)
+        .all()
+    )
+    assert len(builds) == 1
+    for b in builds:
+        assert b.package.channel_id == 2
+    count = populated_db.query(orm.CondaPackageBuild).count()
+    assert count == 4
+
+
+@mock.patch("conda_store_server._internal.conda_utils.download_repodata")
+def test_update_packages_multiple_builds(mock_repdata, populated_db, test_repodata_multiple_packages):
+    # mock download_repodata to return static test repodata
+    mock_repdata.return_value = test_repodata_multiple_packages
+
+    count = populated_db.query(orm.CondaPackageBuild).count()
+    assert count == 3
+
+    channel = (
+        populated_db.query(orm.CondaChannel).filter(orm.CondaChannel.id == 2).first()
+    )
+    channel.update_packages(populated_db, "linux-64")
+
+    # ensure the package is not added conda packages
+    count = populated_db.query(orm.CondaPackage).count()
+    assert count == 2
+
+    # ensure it is added to conda package builds
+    count = populated_db.query(orm.CondaPackageBuild).count()
+    assert count == 5
+    builds = (
+        populated_db.query(orm.CondaPackageBuild)
+        .filter(orm.CondaPackageBuild.channel_id == 2)
+        .all()
+    )
+    assert len(builds) == 2
+    for b in builds:
+        assert b.package.channel_id == 2
+
+
+@mock.patch("conda_store_server._internal.conda_utils.download_repodata")
+def test_update_packages_channel_consistency(mock_repdata, populated_db, test_repodata_multiple_packages):
+    mock_repdata.return_value = test_repodata_multiple_packages
+
+    channel = (
+        populated_db.query(orm.CondaChannel).filter(orm.CondaChannel.id == 2).first()
+    )
+    channel.update_packages(populated_db, "linux-64")
+
+    # ensure the package builds end up with the correct channel
+    builds = (
+        populated_db.query(orm.CondaPackageBuild)
+        .filter(orm.CondaPackageBuild.channel_id == 2)
+        .all()
+    )
+    for b in builds:
+        assert b.channel_id == 2
+        assert b.package.channel_id == 2
+
+    # again with another channel
+    channel = (
+        populated_db.query(orm.CondaChannel).filter(orm.CondaChannel.id == 1).first()
+    )
+    channel.update_packages(populated_db, "linux-64")
+
+    # ensure the package builds end up with the correct channel
+    builds = (
+        populated_db.query(orm.CondaPackageBuild)
+        .filter(orm.CondaPackageBuild.channel_id == 1)
+        .all()
+    )
+    for b in builds:
+        assert b.channel_id == 1
+        assert b.package.channel_id == 1


### PR DESCRIPTION
related to https://github.com/conda-incubator/conda-store/issues/852

## Description

Previously, whenever the packages for a channel would get updated, duplicated packages across channels would cause an sql error.

```
conda-store-worker-1  | (Background on this error at: https://sqlalche.me/e/14/gkpj)
conda-store-worker-1  | [2024-11-07 05:27:06,310: ERROR/ForkPoolWorker-5] Task task_update_conda_channel[73d1f6c4-e39e-4d77-a73d-0a61c5824648] raised unexpected: IntegrityError('(psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "_conda_package_build_uc"\nDETAIL:  Key (channel_id, package_id, subdir, build, build_number, sha256)=(3, 5618, linux-64, py27_0, 0, d65b4ca2fa3e2e9f6dc84b4883255c395a381bb11a3009c2f6fefa24aa284db8) already exists.\n')
conda-store-worker-1  | Traceback (most recent call last):
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1890, in _execute_context
conda-store-worker-1  |     self.dialect.do_executemany(
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 982, in do_executemany
conda-store-worker-1  |     context._psycopg2_fetched_rows = xtras.execute_values(
conda-store-worker-1  |                                      ^^^^^^^^^^^^^^^^^^^^^
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/psycopg2/extras.py", line 1299, in execute_values
conda-store-worker-1  |     cur.execute(b''.join(parts))
conda-store-worker-1  | psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "_conda_package_build_uc"
conda-store-worker-1  | DETAIL:  Key (channel_id, package_id, subdir, build, build_number, sha256)=(3, 5618, linux-64, py27_0, 0, d65b4ca2fa3e2e9f6dc84b4883255c395a381bb11a3009c2f6fefa24aa284db8) already exists.
conda-store-worker-1  | 
conda-store-worker-1  | 
conda-store-worker-1  | The above exception was the direct cause of the following exception:
conda-store-worker-1  | 
conda-store-worker-1  | Traceback (most recent call last):
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/celery/app/trace.py", line 453, in trace_task
conda-store-worker-1  |     R = retval = fun(*args, **kwargs)
conda-store-worker-1  |                  ^^^^^^^^^^^^^^^^^^^^
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/celery/app/trace.py", line 736, in __protected_call__
conda-store-worker-1  |     return self.run(*args, **kwargs)
conda-store-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^
conda-store-worker-1  |   File "/opt/conda-store-server/conda_store_server/_internal/worker/tasks.py", line 191, in task_update_conda_channel
conda-store-worker-1  |     channel.update_packages(db, subdirs=settings.conda_platforms)
conda-store-worker-1  |   File "/opt/conda-store-server/conda_store_server/_internal/orm.py", line 685, in update_packages
conda-store-worker-1  |     raise e
conda-store-worker-1  |   File "/opt/conda-store-server/conda_store_server/_internal/orm.py", line 679, in update_packages
conda-store-worker-1  |     db.bulk_insert_mappings(CondaPackageBuild, flatten)
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3810, in bulk_insert_mappings
conda-store-worker-1  |     self._bulk_save_mappings(
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3912, in _bulk_save_mappings
conda-store-worker-1  |     with util.safe_reraise():
conda-store-worker-1  |          ^^^^^^^^^^^^^^^^^^^
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
conda-store-worker-1  |     compat.raise_(
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
conda-store-worker-1  |     raise exception
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3901, in _bulk_save_mappings
conda-store-worker-1  |     persistence._bulk_insert(
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/orm/persistence.py", line 107, in _bulk_insert
conda-store-worker-1  |     _emit_insert_statements(
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/orm/persistence.py", line 1097, in _emit_insert_statements
conda-store-worker-1  |     c = connection._execute_20(
conda-store-worker-1  |         ^^^^^^^^^^^^^^^^^^^^^^^
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1710, in _execute_20
conda-store-worker-1  |     return meth(self, args_10style, kwargs_10style, execution_options)
conda-store-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
conda-store-worker-1  |     return connection._execute_clauseelement(
conda-store-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
conda-store-worker-1  |     ret = self._execute_context(
conda-store-worker-1  |           ^^^^^^^^^^^^^^^^^^^^^^
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1953, in _execute_context
conda-store-worker-1  |     self._handle_dbapi_exception(
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 2134, in _handle_dbapi_exception
conda-store-worker-1  |     util.raise_(
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
conda-store-worker-1  |     raise exception
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1890, in _execute_context
conda-store-worker-1  |     self.dialect.do_executemany(
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 982, in do_executemany
conda-store-worker-1  |     context._psycopg2_fetched_rows = xtras.execute_values(
conda-store-worker-1  |                                      ^^^^^^^^^^^^^^^^^^^^^
conda-store-worker-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/psycopg2/extras.py", line 1299, in execute_values
conda-store-worker-1  |     cur.execute(b''.join(parts))
conda-store-worker-1  | sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "_conda_package_build_uc"
conda-store-worker-1  | DETAIL:  Key (channel_id, package_id, subdir, build, build_number, sha256)=(3, 5618, linux-64, py27_0, 0, d65b4ca2fa3e2e9f6dc84b4883255c395a381bb11a3009c2f6fefa24aa284db8) already exists.
conda-store-worker-1  | 
conda-store-worker-1  | [SQL: INSERT INTO conda_package_build (package_id, channel_id, build, build_number, constrains, depends, md5, sha256, size, subdir, timestamp) VALUES (%(package_id)s, %(channel_id)s, %(build)s, %(build_number)s, %(constrains)s, %(depends)s, %(md5)s, %(sha256)s, %(size)s, %(subdir)s, %(timestamp)s)]
```

The root of the issue was that `conda_package_builds` were not getting the correct package/channel reference. For example, see the state of the db after a package update was run. In particular, the `package_id` with different `channel_id`'s. This is incorrect, the `channel_id` should match the package's channel id. So, for the `package_id` 5618, that should be `channel_id` 1.

```
conda-store=# select * from conda_package where name='hyperlink' and version='18.0.0'
conda-store-# ;
  id  | channel_id | license | license_family |   name    | version |              summary               | description 
------+------------+---------+----------------+-----------+---------+------------------------------------+-------------
 9558 |          3 | MIT     | MIT            | hyperlink | 18.0.0  | Immutable, Pythonic, correct URLs. | 
 5618 |          1 | MIT     | MIT            | hyperlink | 18.0.0  | Immutable, Pythonic, correct URLs. | 
(2 rows)

conda-store=# select package_id, channel_id, id, build from conda_package_build where package_id = 9558 or package_id = 5618
conda-store-# ;
 package_id | channel_id |  id   | build  
------------+------------+-------+--------
       5618 |          1 | 29288 | py27_0
       5618 |          3 | 26873 | py27_0
       5618 |          3 | 26874 | py35_0
       5618 |          3 | 26875 | py36_0
       5618 |          3 | 26876 | py37_0
       5618 |          1 | 29289 | py35_0
       5618 |          1 | 29290 | py36_0
       5618 |          1 | 29291 | py37_0
(8 rows)

```

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

