### PR TITLE
Retry updating conda packages

### DIFF
--- a/conda-store-server/conda_store_server/_internal/orm.py
+++ b/conda-store-server/conda_store_server/_internal/orm.py
@@ -467,11 +467,11 @@ class CondaChannel(Base):
     name = Column(Unicode(255), unique=True, nullable=False)
     last_update = Column(DateTime)
 
-    # The conda_package table also gets updated during an environment build. It is 
+    # The conda_package table also gets updated during an environment build. It is
     # possible for an entry to be inserted into the table between the step where
     # existing package keys are computed and the bulk insert is executed. This will
-    # cause the bulk update to fail with an IntegrityError (eg. in postrgres this is a 
-    # psycopg2.errors.UniqueViolation error). In this case, we'll want to retry updating 
+    # cause the bulk update to fail with an IntegrityError (eg. in postrgres this is a
+    # psycopg2.errors.UniqueViolation error). In this case, we'll want to retry updating
     # the conda packages
     @utils.retry_on_errors(allowed_retries=1, on_errors=(IntegrityError), logger=logger)
     def update_conda_packages(self, db, repodata, architecture):
@@ -529,7 +529,7 @@ class CondaChannel(Base):
         except Exception as e:
             db.rollback()
             raise e
-        
+
         logger.info("insert packages done")
 
     def update_conda_package_builds(self, db, repodata, architecture):
@@ -623,12 +623,8 @@ class CondaChannel(Base):
                         CondaPackage.version == p_version,
                     )
                 )
-            all_parent_packages = (
-                db.query(CondaPackage).filter(or_(*statements)).all()
-            )
-            all_parent_packages = {
-                (_.name, _.version): _ for _ in all_parent_packages
-            }
+            all_parent_packages = db.query(CondaPackage).filter(or_(*statements)).all()
+            all_parent_packages = {(_.name, _.version): _ for _ in all_parent_packages}
             logger.info(f"parent packages retrieved : {len(all_parent_packages)} ")
 
             for p_name, p_version in subset_keys:

--- a/conda-store-server/conda_store_server/_internal/utils.py
+++ b/conda-store-server/conda_store_server/_internal/utils.py
@@ -3,6 +3,7 @@
 # license that can be found in the LICENSE file.
 
 import contextlib
+import functools
 import hashlib
 import json
 import os
@@ -11,7 +12,6 @@ import re
 import subprocess
 import sys
 import time
-import functools
 from typing import AnyStr
 
 from filelock import FileLock
@@ -195,7 +195,7 @@ def retry_on_errors(allowed_retries=1, on_errors=(), logger=None):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             num_retries = 0
-            while num_retries <= allowed_retries:            
+            while num_retries <= allowed_retries:
                 try:
                     result = func(*args, **kwargs)
                 except on_errors as e:
@@ -207,5 +207,7 @@ def retry_on_errors(allowed_retries=1, on_errors=(), logger=None):
                 else:
                     return result
             return result
+
         return wrapper
+
     return decorator_retry

--- a/conda-store-server/tests/_internal/test_utils.py
+++ b/conda-store-server/tests/_internal/test_utils.py
@@ -3,6 +3,7 @@
 # license that can be found in the LICENSE file.
 
 import pytest
+
 from conda_store_server._internal.utils import disk_usage, du, retry_on_errors
 
 # TODO: Add tests for the other functions in utils.py
@@ -43,7 +44,7 @@ class MyTestError(Exception):
 
 
 def test_retry_on_error():
-    class MyTestClass():
+    class MyTestClass:
         def __init__(self):
             self.called = 0
 
@@ -51,9 +52,9 @@ def test_retry_on_error():
         def raise_my_test_exception(self):
             self.called += 1
             raise MyTestError
-    
+
     tc = MyTestClass()
-    
+
     with pytest.raises(MyTestError):
         tc.raise_my_test_exception()
 
@@ -61,7 +62,7 @@ def test_retry_on_error():
 
 
 def test_retry_on_not_covered_error():
-    class MyTestClass():
+    class MyTestClass:
         def __init__(self):
             self.called = 0
 
@@ -69,12 +70,12 @@ def test_retry_on_not_covered_error():
         def raise_my_test_exception(self):
             self.called += 1
             raise MyTestError
-    
+
     tc = MyTestClass()
-    
+
     with pytest.raises(MyTestError):
         tc.raise_my_test_exception()
-    
+
     assert tc.called == 1
 
 
@@ -82,6 +83,6 @@ def test_retry_no_error():
     @retry_on_errors(allowed_retries=1, on_errors=(MyTestError))
     def test_function():
         return 1
-    
+
     result = test_function()
     assert result == 1


### PR DESCRIPTION
Fixes #852

## Description

Th issue described in #852 arises because part of the[ environment build process](https://github.com/conda-incubator/conda-store/blob/main/conda-store-server/conda_store_server/_internal/worker/build.py#L292) is to execute the [`action_add_conda_prefix_package`](https://github.com/conda-incubator/conda-store/blob/main/conda-store-server/conda_store_server/_internal/action/add_conda_prefix_packages.py#L61). This action tries to insert all the packages from the environment into the db. If these packages overlap with any of the packages inserted by `task_update_conda_channel` (which is common on a first run of the task) then we get the integrity error. 

This PR adds a retry to the part of the `task_update_conda_channel` task that updates the conda_package table.  So, if an integrity error occurs due to a package getting inserted by another process while a bulk update is happening, then the whole process for inserting the conda packages will try again. Subsequent bulk inserts are expected to work, since part of the update process is to only insert packages that haven't already been added.

Other options I looked out to resolve this issue are:
* using an [upsert statements](https://docs.sqlalchemy.org/en/20/orm/queryguide/dml.html#orm-upsert-statements) instead of an insert statement
  * sqlalchemy does not provide a platform agnostic way to do upserts. Since conda-store is meant to be db platform agnostic, I think this is not an great option.
* briefly looked into locking the conda_package table to writes while the bulk insert is happening. 
  * I don't think this is a great option since it's pretty heavy handed and may have unintentional consequences as the system evolves.  

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?


