### PR TITLE
MAINT - Do not use `nodefaults` moving forward

### DIFF
--- a/.github/workflows/generate_api_docs.yaml
+++ b/.github/workflows/generate_api_docs.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: conda-store-server/environment-dev.yaml
+          conda-remove-defaults: "true"
 
       - name: "Install conda-store-server 📦"
         run: python -m pip install conda-store-server/.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ env:
 
 permissions:
   contents: read # This is required for actions/checkout
+  attestations: write
+  id-token: write # Needed for attestations
 
 jobs:
   # Always build & verify package.
@@ -44,6 +46,7 @@ jobs:
         with:
           path: ${{ matrix.directory }}
           upload-name-suffix: "-${{ matrix.directory }}"
+          attest-build-provenance-github: "true"
 
       - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }} and in artifact ${{ steps.baipp.outputs.artifact-name }}
 

--- a/.github/workflows/test_conda_store_server_integration.yaml
+++ b/.github/workflows/test_conda_store_server_integration.yaml
@@ -50,6 +50,7 @@ jobs:
             auto-activate-base: false
             activate-environment: conda-store-server-dev
             python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+            conda-remove-defaults: "true"
 
       - name: "Install dependencies 📦"
         run: |

--- a/.github/workflows/test_conda_store_server_unit.yaml
+++ b/.github/workflows/test_conda_store_server_unit.yaml
@@ -73,6 +73,7 @@ jobs:
             auto-activate-base: false
             activate-environment: conda-store-server-dev
             python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+            conda-remove-defaults: "true"
 
       # This fixes a "DLL not found" issue importing ctypes from the hatch env
       - name: "Reinstall Python on Windows runner"

--- a/conda-store-server/environment-dev.yaml
+++ b/conda-store-server/environment-dev.yaml
@@ -11,7 +11,6 @@
 name: conda-store-server-dev
 channels:
   - conda-forge
-  - nodefaults
 dependencies:
   # must be kept in sync with .python-version-default
   - python=3.12


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/962

## Description

- While reviewing another PR, I realised there are a lot of warnings regarding the use of `nodefaults` due to changes in conda and miniconda-setup related to removing the `default` population in channels. This PR makes the necessary updates to remove these warnings.
- Since I was touching workflows, I decided to add the `attest-build-provenance-github` configuration to our release action to also generate GH attestions


## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
## How to test

<!-- Steps to take to test the new feature, verify the bug is fixed, etc. Please do not just include steps for the happy path, but failure modes too. -->
