### PR TITLE
DEV - Set traitlets application version

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -46,6 +46,7 @@ class _Color(str, Enum):
 
 
 class CondaStoreServer(Application):
+    version = __version__
     aliases = {
         "config": "CondaStoreServer.config_file",
     }

--- a/conda-store-server/conda_store_server/_internal/worker/app.py
+++ b/conda-store-server/conda_store_server/_internal/worker/app.py
@@ -6,10 +6,10 @@ import logging
 import os
 import sys
 
-from conda_store_server import __version__
 from traitlets import Integer, List, Unicode, validate
 from traitlets.config import Application, catch_config_error
 
+from conda_store_server import __version__
 from conda_store_server.app import CondaStore
 
 

--- a/conda-store-server/conda_store_server/_internal/worker/app.py
+++ b/conda-store-server/conda_store_server/_internal/worker/app.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 
+from conda_store_server import __version__
 from traitlets import Integer, List, Unicode, validate
 from traitlets.config import Application, catch_config_error
 
@@ -13,6 +14,7 @@ from conda_store_server.app import CondaStore
 
 
 class CondaStoreWorker(Application):
+    version = __version__
     aliases = {
         "config": "CondaStoreWorker.config_file",
     }


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/977

## Description

This pr set's up the traitlets application to know the current version of conda-store. Setting the version property of a traitlets Application will allow the built in trailtlets '--version' flag to work properly.

For example, running `conda-store-server --version` now works properly
```
 $ conda-store-server --version 
2024.11.1
 $ conda-store-worker --version
2024.11.1
```

ref:
  https://github.com/ipython/traitlets/blob/main/traitlets/config/application.py#L872
  https://github.com/ipython/traitlets/blob/main/traitlets/config/application.py#L200


## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

