### PR TITLE
Seperate out workflows for building pypi packages per test and release use cases

### DIFF
--- a/.github/workflows/build_pypi_package.yaml
+++ b/.github/workflows/build_pypi_package.yaml
@@ -1,0 +1,48 @@
+name: "Build PyPI package"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "conda-store/**"
+      - "conda-store-server/**"
+      - "tests/**"
+  push:
+    branches:
+      - main
+
+env:
+  FORCE_COLOR: "1" # Make tools pretty.
+
+permissions:
+  contents: read # This is required for actions/checkout
+
+jobs:
+  # Always build & verify package.
+  build-package:
+    name: "Build & verify package"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory:
+          - "conda-store"
+          - "conda-store-server"
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
+    steps:
+      - name: "Checkout Repository 🛎"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: echo "Running on ${{ matrix.directory }}"
+
+      - name: "Build and check package - ${{ matrix.directory }} 📦"
+        uses: hynek/build-and-inspect-python-package@v2
+        id: baipp
+        with:
+          path: ${{ matrix.directory }}
+          upload-name-suffix: "-${{ matrix.directory }}"
+
+      - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }} and in artifact ${{ steps.baipp.outputs.artifact-name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,10 @@
-name: "Build and maybe upload PyPI package"
+name: "Build and upload PyPI package"
 
 on:
   release:
     types: [published]
   push:
-    branches: [main]
     tags: ["*"]
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Context
PR's coming from forks of users with improper github access have the "Builds and maybe upload PyPI package" workflow failing. For example:
* https://github.com/conda-incubator/conda-store/pull/980
* https://github.com/conda-incubator/conda-store/pull/981

The error produced is:
```
Error: Failed to get ID token: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

However, the workflow already has [the required permissions set](https://github.com/conda-incubator/conda-store/blob/main/.github/workflows/release.yaml#L20).
 
## Description
This PR proposes separating out the 2 use cases for building pypi packages. These are
 1. building pypi packages for every pr to test the pr
 2. building pypi packages for a release to be uploaded to pypi (requires attestation)

Now, there are the worflows:
 * build_pypi_package
   * just builds and inspects the pypi package
   * runs on every pr
 * release
   * builds, inspects, attest, upload pypi package
   * only runs on releases

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

Refs:
https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#configuring-required-approval-for-workflows-from-public-forks
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository