### PR TITLE
Ensure api url setting has trailing slash

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/templates/conda-store-ui.html
+++ b/conda-store-server/conda_store_server/_internal/server/templates/conda-store-ui.html
@@ -22,7 +22,7 @@ https://conda.store/conda-store-ui/how-tos/configure-ui -->
              REACT_APP_AUTH_TOKEN: "",
              REACT_APP_STYLE_TYPE: "green-accent",
              REACT_APP_SHOW_LOGIN_ICON: "true",
-             REACT_APP_API_URL: "{{ url_for('redirect_root_to_ui') }}",
+             REACT_APP_API_URL: "{{ url_for('redirect_root_to_ui') }}/",
              REACT_APP_LOGIN_PAGE_URL: "{{ url_for('get_login_method') }}?next=",
              REACT_APP_LOGOUT_PAGE_URL: "{{ url_for('post_logout_method') }}?next=/",
              REACT_APP_URL_BASENAME: "{{ url_prefix.rstrip('/') }}{{ ui_prefix }}"


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/995


## Description

This is required for the "log and artifact" links in the ui to work. 

For example, follow the instructions in #995 to reproduce the issue. With this change, the links provided in the `Logs and Artifacts` section correctly point to `/conda-store/api/v1/<rest of the api path>`.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- x Did you update the documentation (if required)?
- x Did you add/update relevant tests for this change (if required)?

