### PR TITLE
Release helper script

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -22,34 +22,24 @@ Release captain responsible - <@gh_username>
 
 ### 2. Prepare the codebase for a new release
 
-- [ ] Create a new git branch for the release `git checkout -b release-2024.9.1`
-  - [ ] Prepare the branch just in case `git clean -fxdq`
-- [ ] Bump `conda-store` version in [`conda-store/conda-store/__init__.py`](https://github.com/conda-incubator/conda-store/blob/main/conda-store/conda_store/__init__.py)
-- [ ] Bump `conda-store-server` version in [`conda-store-server/conda-store-server/__init__.py`](https://github.com/conda-incubator/conda-store/blob/main/conda-store/conda_store/__init__.py)
-- [ ] Update the `conda-store-ui` version used in `conda-store-server` [`conda-store-server/hatch_build.py`](https://github.com/conda-incubator/conda-store/blob/main/conda-store-server/hatch_build.py)
-- [ ] Update the [CHANGELOG.md](./CHANGELOG.md) file with the new version, release date, and relevant changes[^github-activity].
-- [ ] Check the version locally with `hatch version`
-- [ ] Build and test locally
-  - [ ] For `conda-store` and `conda-store-server`:
+- [ ] Prepare the release by running the `cut-release-pr.sh` script
 
-    ```bash
-    # Note you will need to run this twice, once for each package
-    cd conda-store # or cd conda-store-server
-    hatch build
-    twine check dist/*
-    hatch clean
-    ```
+  ```bash
+  ./cut-release-pr.sh -r <conda-store version> -c <conda-store-ui version>
+  ```
 
-  - [ ] After building `conda-store-server` and before `hatch clean` run the server in standalone mode:
+  - [ ] Ensure that the conda-store, conda-store-server, conda-store-ui versions have been updated
+
+  - [ ] Manually review the CHANGELOG and remove/organize important contributions
+
+- [ ] Test that the application is working. In particular, do a manual inspection of the build and `ui` vendoring process:
 
     ```bash
     cd conda-store-server
+    hatch build
     conda-store-server --standalone
     ```
 
-    To do a manual inspection of the build and `ui` vendoring process.
-
-- [ ] Make a release commit: ``git commit -m 'REL - 2024.9.1'``
 - [ ] Push the release (REL) commit ``git push upstream main``
 - [ ] If a **release candidate** is needed, tick this box when we're ready for a full release.
 
@@ -70,5 +60,3 @@ Release captain responsible - <@gh_username>
 - [ ] Open a follow-up PR to bump `conda-store` and `conda-store-server` versions to the next dev-release number (for example `2024.10.1`).
 - [ ] Open a follow-up PR to bump the `conda-store-server` version in the [`conda-store-ui` compose file](https://github.com/conda-incubator/conda-store-ui/blob/main/docker-compose.yml).
 - [ ] Celebrate, you're done! 🎉
-
-[^github-activity]: If you wish, use [`github-activity` to generate a Changelog](https://github.com/choldgraf/github-activity), e.g. `github-activity conda-incubator/conda-store --since 2024.9.1 --until 2023.10.1`.

--- a/cut-release-pr.sh
+++ b/cut-release-pr.sh
@@ -16,7 +16,7 @@ function build_and_check () {
     # Runs a hatch build, twine check, and checks the version of the package
     # Assumes that you are in the directory for the package
     #
-    # args: 
+    # args:
     #   CHECK_TARGET: the name of the package to check
     CHECK_TARGET=$1
 
@@ -75,9 +75,9 @@ done
 CURRENT_DATE=$(date '+%Y-%m-%d')
 
 echo "Today is ${CURRENT_DATE}
-Building a release for 
+Building a release for
   * conda-store version ${RELEASE_VERSION}
-with 
+with
   * conda-store-ui version ${CONDA_STORE_UI_VERSION}
 "
 
@@ -86,9 +86,9 @@ git checkout -b release-"$RELEASE_VERSION"
 git clean -fxdq
 
 # bump versions
-sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-store-server/conda_store_server/__init__.py 
-sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-store/conda_store/__init__.py 
-sed -E -r -i "s/CONDA_STORE_UI_VERSION = .+/CONDA_STORE_UI_VERSION = \"$CONDA_STORE_UI_VERSION\"/g" conda-store-server/hatch_build.py      
+sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-store-server/conda_store_server/__init__.py
+sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-store/conda_store/__init__.py
+sed -E -r -i "s/CONDA_STORE_UI_VERSION = .+/CONDA_STORE_UI_VERSION = \"$CONDA_STORE_UI_VERSION\"/g" conda-store-server/hatch_build.py
 
 # create changelog
 LATEST_TAG=$(curl https://api.github.com/repos/conda-incubator/conda-store/releases | jq -r '.[0].tag_name')

--- a/cut-release-pr.sh
+++ b/cut-release-pr.sh
@@ -23,11 +23,24 @@ function build_and_check () {
     echo "${CHECK_TARGET}: Checking hatch versions..."
     HV=$(hatch version)
     if [[ "$HV" == "$RELEASE_VERSION" ]]; then
-        echo "${CHECK_TARGET} hatch version is matching the requested release version ${RELEASE_VERSION}"
+        echo "${CHECK_TARGET}: hatch version matches ${RELEASE_VERSION}"
     else
-        echo "${CHECK_TARGET} hatch version does not match the requested release version. Something has gone wrong, exiting!"
+        echo "${CHECK_TARGET}: hatch version does not match the requested release version. Something has gone wrong, exiting!"
         exit 1
     fi
+
+    echo "${CHECK_TARGET}: Running build and checking package..."
+    hatch build
+    rc=$(twine check dist/*)
+    if [[ $rc =~ "FAILED" ]]; then
+        echo "${CHECK_TARGET}: package is not in a good state, exiting!"
+        exit 1
+    else
+        echo "${CHECK_TARGET}: package is in a good state"
+    fi
+
+    echo "${CHECK_TARGET}: cleaning up..."
+    hatch clean
 }
 
 while [[ $# -gt 0 ]]
@@ -69,8 +82,8 @@ with
 "
 
 # prepare repo
-# git checkout -b release-"$RELEASE_VERSION"
-# git clean -fxdq
+git checkout -b release-"$RELEASE_VERSION"
+git clean -fxdq
 
 # bump versions
 sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-store-server/conda_store_server/__init__.py 
@@ -78,17 +91,17 @@ sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-sto
 sed -E -r -i "s/CONDA_STORE_UI_VERSION = .+/CONDA_STORE_UI_VERSION = \"$CONDA_STORE_UI_VERSION\"/g" conda-store-server/hatch_build.py      
 
 # create changelog
-# LATEST_TAG=$(curl https://api.github.com/repos/conda-incubator/conda-store/releases | jq -r '.[0].tag_name')
-# PYTHONWARNINGS="ignore" github-activity conda-incubator/conda-store --since $LATEST_TAG --heading-level=2 > tmp_changes.txt
-# # remove first line of changes - it's always a message about which GH token is used
-# sed -n -i '1!p' tmp_changes.txt
-# # replace the header for the changes with the appropriate title
-# sed -n -i '1!p' tmp_changes.txt
-# sed -i "1s/^/## [$RELEASE_VERSION] - $CURRENT_DATE\n/" tmp_changes.txt
-# # insert changes into changelog
-# sed -i "/---/r tmp_changes.txt" CHANGELOG.md
-# # clean up temp file
-# rm tmp_changes.txt
+LATEST_TAG=$(curl https://api.github.com/repos/conda-incubator/conda-store/releases | jq -r '.[0].tag_name')
+PYTHONWARNINGS="ignore" github-activity conda-incubator/conda-store --since $LATEST_TAG --heading-level=2 > tmp_changes.txt
+# remove first line of changes - it's always a message about which GH token is used
+sed -n -i '1!p' tmp_changes.txt
+# replace the header for the changes with the appropriate title
+sed -n -i '1!p' tmp_changes.txt
+sed -i "1s/^/## [$RELEASE_VERSION] - $CURRENT_DATE\n/" tmp_changes.txt
+# insert changes into changelog
+sed -i "/---/r tmp_changes.txt" CHANGELOG.md
+# clean up temp file
+rm tmp_changes.txt
 
 cd conda-store-server
 build_and_check conda-store-server
@@ -100,8 +113,8 @@ cd ..
 
 
 # # add files to git
-# git add conda-store conda-store-server CHANGELOG.md
-# git commit -m "REL - $RELEASE_VERSION"
+git add conda-store conda-store-server CHANGELOG.md
+git commit -m "REL - $RELEASE_VERSION"
 
 echo "
 Finished preparing the release!

--- a/cut-release-pr.sh
+++ b/cut-release-pr.sh
@@ -5,12 +5,30 @@
 #   - github-activity https://github.com/choldgraf/github-activity
 #   - jq
 # - GITHUB_ACCESS_TOKEN env var set
+# - `conda-store-server-dev` conda env is activated
 
 function usage {
     echo -e "Usage: ./cut-release-pr.sh -r release_version -c conda_store_ui_version\n"
     exit 1
 }
 
+function build_and_check () {
+    # Runs a hatch build, twine check, and checks the version of the package
+    # Assumes that you are in the directory for the package
+    #
+    # args: 
+    #   CHECK_TARGET: the name of the package to check
+    CHECK_TARGET=$1
+
+    echo "${CHECK_TARGET}: Checking hatch versions..."
+    HV=$(hatch version)
+    if [[ "$HV" == "$RELEASE_VERSION" ]]; then
+        echo "${CHECK_TARGET} hatch version is matching the requested release version ${RELEASE_VERSION}"
+    else
+        echo "${CHECK_TARGET} hatch version does not match the requested release version. Something has gone wrong, exiting!"
+        exit 1
+    fi
+}
 
 while [[ $# -gt 0 ]]
 do
@@ -51,8 +69,8 @@ with
 "
 
 # prepare repo
-git checkout -b release-"$RELEASE_VERSION"
-git clean -fxdq
+# git checkout -b release-"$RELEASE_VERSION"
+# git clean -fxdq
 
 # bump versions
 sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-store-server/conda_store_server/__init__.py 
@@ -60,43 +78,30 @@ sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-sto
 sed -E -r -i "s/CONDA_STORE_UI_VERSION = .+/CONDA_STORE_UI_VERSION = \"$CONDA_STORE_UI_VERSION\"/g" conda-store-server/hatch_build.py      
 
 # create changelog
-LATEST_TAG=$(curl https://api.github.com/repos/conda-incubator/conda-store/releases | jq -r '.[0].tag_name')
-PYTHONWARNINGS="ignore" github-activity conda-incubator/conda-store --since $LATEST_TAG --heading-level=2 > tmp_changes.txt
-# remove first line of changes - it's always a message about which GH token is used
-sed -n -i '1!p' tmp_changes.txt
-# replace the header for the changes with the appropriate title
-sed -n -i '1!p' tmp_changes.txt
-sed -i "1s/^/## [$RELEASE_VERSION] - $CURRENT_DATE\n/" tmp_changes.txt
-# insert changes into changelog
-sed -i "/---/r tmp_changes.txt" CHANGELOG.md
-# clean up temp file
-rm tmp_changes.txt
+# LATEST_TAG=$(curl https://api.github.com/repos/conda-incubator/conda-store/releases | jq -r '.[0].tag_name')
+# PYTHONWARNINGS="ignore" github-activity conda-incubator/conda-store --since $LATEST_TAG --heading-level=2 > tmp_changes.txt
+# # remove first line of changes - it's always a message about which GH token is used
+# sed -n -i '1!p' tmp_changes.txt
+# # replace the header for the changes with the appropriate title
+# sed -n -i '1!p' tmp_changes.txt
+# sed -i "1s/^/## [$RELEASE_VERSION] - $CURRENT_DATE\n/" tmp_changes.txt
+# # insert changes into changelog
+# sed -i "/---/r tmp_changes.txt" CHANGELOG.md
+# # clean up temp file
+# rm tmp_changes.txt
 
-echo "Checking hatch versions..."
 cd conda-store-server
-HV=$(hatch version)
-if [[ "$HV" == "$RELEASE_VERSION" ]]; then
-    echo "conda-store-server hatch version is matching the requested release version ${RELEASE_VERSION}"
-else
-    echo "conda-store-server hatch version does not match the requested release version. Something has gone wrong, exiting!"
-    exit 1
-fi
+build_and_check conda-store-server
+cd ..
 
-cd ../conda-store
-HV=$(hatch version)
-if [[ "$HV" == "$RELEASE_VERSION" ]]; then
-    echo "conda-store hatch version is matching the requested release version ${RELEASE_VERSION}"
-else
-    echo "conda-store hatch version does not match the requested release version. Something has gone wrong, exiting!"
-    exit 1
-fi
-
+cd conda-store
+build_and_check conda-store
 cd ..
 
 
-# add files to git
-git add conda-store conda-store-server CHANGELOG.md
-git commit -m "REL - $RELEASE_VERSION"
+# # add files to git
+# git add conda-store conda-store-server CHANGELOG.md
+# git commit -m "REL - $RELEASE_VERSION"
 
 echo "
 Finished preparing the release!

--- a/cut-release-pr.sh
+++ b/cut-release-pr.sh
@@ -112,7 +112,7 @@ build_and_check conda-store
 cd ..
 
 
-# # add files to git
+# add files to git
 git add conda-store conda-store-server CHANGELOG.md
 git commit -m "REL - $RELEASE_VERSION"
 

--- a/cut-release-pr.sh
+++ b/cut-release-pr.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Requirements
+# - packages
+#   - github-activity https://github.com/choldgraf/github-activity
+#   - jq
+# - GITHUB_ACCESS_TOKEN env var set
+
+function usage {
+    echo -e "Usage: ./cut-release-pr.sh -r release_version -c conda_store_ui_version\n"
+    exit 1
+}
+
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -h|--help)
+    usage
+    exit 0
+    shift
+    shift
+    ;;
+    -r|--release_version)
+    RELEASE_VERSION="$2"
+    shift
+    shift
+    ;;
+    -c|--conda_store_ui_version)
+    CONDA_STORE_UI_VERSION="$2"
+    shift
+    shift
+    ;;
+    *)
+    usage
+    exit 0
+    shift
+    ;;
+esac
+done
+
+CURRENT_DATE=$(date '+%Y-%m-%d')
+
+echo "Today is ${CURRENT_DATE}
+Building a release for 
+  * conda-store version ${RELEASE_VERSION}
+with 
+  * conda-store-ui version ${CONDA_STORE_UI_VERSION}
+"
+
+# prepare repo
+git checkout -b release-"$RELEASE_VERSION"
+git clean -fxdq
+
+# bump versions
+sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-store-server/conda_store_server/__init__.py 
+sed -E -r -i "s/__version__ = .+/__version__ = \"$RELEASE_VERSION\"/g" conda-store/conda_store/__init__.py 
+sed -E -r -i "s/CONDA_STORE_UI_VERSION = .+/CONDA_STORE_UI_VERSION = \"$CONDA_STORE_UI_VERSION\"/g" conda-store-server/hatch_build.py      
+
+# create changelog
+LATEST_TAG=$(curl https://api.github.com/repos/conda-incubator/conda-store/releases | jq -r '.[0].tag_name')
+PYTHONWARNINGS="ignore" github-activity conda-incubator/conda-store --since $LATEST_TAG --heading-level=2 > tmp_changes.txt
+# remove first line of changes - it's always a message about which GH token is used
+sed -n -i '1!p' tmp_changes.txt
+# replace the header for the changes with the appropriate title
+sed -n -i '1!p' tmp_changes.txt
+sed -i "1s/^/## [$RELEASE_VERSION] - $CURRENT_DATE\n/" tmp_changes.txt
+# insert changes into changelog
+sed -i "/---/r tmp_changes.txt" CHANGELOG.md
+# clean up temp file
+rm tmp_changes.txt
+
+echo "Checking hatch versions..."
+cd conda-store-server
+HV=$(hatch version)
+if [[ "$HV" == "$RELEASE_VERSION" ]]; then
+    echo "conda-store-server hatch version is matching the requested release version ${RELEASE_VERSION}"
+else
+    echo "conda-store-server hatch version does not match the requested release version. Something has gone wrong, exiting!"
+    exit 1
+fi
+
+cd ../conda-store
+HV=$(hatch version)
+if [[ "$HV" == "$RELEASE_VERSION" ]]; then
+    echo "conda-store hatch version is matching the requested release version ${RELEASE_VERSION}"
+else
+    echo "conda-store hatch version does not match the requested release version. Something has gone wrong, exiting!"
+    exit 1
+fi
+
+cd ..
+
+
+# add files to git
+git add conda-store conda-store-server CHANGELOG.md
+git commit -m "REL - $RELEASE_VERSION"
+
+echo "
+Finished preparing the release!
+
+Next steps:
+  * Validate that the changes made are correct
+  * Follow any testing/validation steps
+  * Push them changes up to github
+
+    git push origin release-"$RELEASE_VERSION"
+"


### PR DESCRIPTION
## Description

This PR proposes a script to automate some manual steps of the current release process. Used this script to cut the latest release (2024.11.2) and it made things go pretty quick and smooth.

Note, this is not a replacement for #861 or #911, we should definitely still do those.

You can test out running this script by (following the setup instructions and then) running

```
$ ./cut-release-pr.sh -r release_version -c conda_store_ui_version
```

This will:
* create a new branch `release-<release_version>`
* put you on that branch
* update the versions of conda-store, conda-store-server, conda-store-ui 
* update the changelog using the `github-activity` tool
* use hatch to build and check the package version
* use twine to check the validity of the package
* commit the changes to your branch with a release commit

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
