### PR TITLE
Remove redundant channel column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ yarn-error.log*
 conda-store.sqlite
 
 *.lockb
+
+# generated test assets
+conda-store-server/tests/alembic.ini

--- a/conda-store-server/conda_store_server/_internal/alembic/script.py.mako
+++ b/conda-store-server/conda_store_server/_internal/alembic/script.py.mako
@@ -1,6 +1,6 @@
-// Copyright (c) conda-store development team. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
 
 """${message}
 

--- a/conda-store-server/conda_store_server/_internal/alembic/versions/89637f546129_remove_conda_package_build_channel.py
+++ b/conda-store-server/conda_store_server/_internal/alembic/versions/89637f546129_remove_conda_package_build_channel.py
@@ -1,0 +1,155 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+"""remove conda package build channel
+
+Revision ID: 89637f546129
+Revises: bf065abf375b
+Create Date: 2024-12-04 13:09:25.562450
+
+"""
+from alembic import op, context
+from sqlalchemy import Column, INTEGER, String, ForeignKey, table, select, engine_from_config, pool
+
+# revision identifiers, used by Alembic.
+revision = '89637f546129'
+down_revision = 'bf065abf375b'
+branch_labels = None
+depends_on = None
+
+
+# This function will go thru all the conda_package_build entries and ensure
+# that the right package_id is associated with it
+def fix_misrepresented_packages(conn):
+    # conda_packages is a hash of channel-id_name_version to conda_package id
+    conda_packages = {}
+
+    conda_package_build_table = table(
+        "conda_package_build",
+        Column("id", INTEGER),
+        Column("channel_id", INTEGER),
+        Column("package_id", INTEGER, ForeignKey("conda_package.id")),
+    )
+    conda_package_table = table(
+        "conda_package",
+        Column("id", INTEGER),
+        Column("channel_id", INTEGER),
+        Column("name", String),
+        Column("version", String),
+    )
+
+    def get_conda_package_id(conn, channel_id, name, version):
+        hashed_name = f"{channel_id}-{name}-{version}"
+        
+        # if package exists in the conda_packages dict, return it
+        if hashed_name in conda_packages:
+            return conda_packages[hashed_name]
+        
+        # if not, then query the db for the package
+        package = conn.execute(
+            select(conda_package_table).where(
+                conda_package_table.c.channel_id == channel_id,
+                conda_package_table.c.name == name,
+                conda_package_table.c.version == version,
+            )
+        ).first()
+
+        # save the package into the conda_packages dict
+        conda_packages[hashed_name] = package.id
+        return package.id
+
+    for row in conn.execute(
+        select(
+            conda_package_build_table.c.id,
+            conda_package_build_table.c.package_id,
+            conda_package_build_table.c.channel_id,
+            conda_package_table.c.name,
+            conda_package_table.c.version
+        ).join(
+            conda_package_build_table,
+            conda_package_build_table.c.package_id == conda_package_table.c.id
+        )
+    ):
+        # the channel_id might already be empty
+        if row[2] is None:
+            continue
+        
+        package_id = get_conda_package_id(conn, row[2], row[3], row[4])
+        # if found package id does not match the found package id, we'll need to updated it
+        if package_id != row[1]:
+            update_package_query = conda_package_build_table.update().where(
+                conda_package_build_table.c.id == op.inline_literal(row[0])
+            ).values(
+                {"package_id": op.inline_literal(package_id)}
+            )
+            conn.execute(update_package_query)
+            conn.commit()
+
+def upgrade():
+    target_table = "conda_package_build"
+    bind = op.get_bind()
+
+    # Due to the issue fixed in https://github.com/conda-incubator/conda-store/pull/961
+    # many conda_package_build entries have the wrong package entry (but the right channel).
+    # Because the packages are duplicated, we can not recreate the _conda_package_build_uc
+    # constraint without the channel_id. 
+    # So, go thru each conda_package_build and re-associate it with the correct conda_package
+    # based on the channel id.
+    fix_misrepresented_packages(bind)
+
+    # remove channel column from constraints
+    op.drop_constraint(
+        constraint_name="_conda_package_build_uc",
+        table_name=target_table,
+    )
+
+    # re-add the constraint without the channel column
+    op.create_unique_constraint(
+        constraint_name="_conda_package_build_uc",
+        table_name=target_table,
+        columns=[ 
+            "package_id",
+            "subdir",
+            "build",
+            "build_number",
+            "sha256",
+        ],
+    )
+
+    # remove channel column
+    op.drop_column(
+        target_table, 
+        "channel_id",
+        mssql_drop_foreign_key=True,
+    )
+
+
+def downgrade():
+    target_table = "conda_package_build"
+
+    # remove channel column from constraints
+    op.drop_constraint(
+        constraint_name="_conda_package_build_uc",
+        table_name=target_table,
+    )
+
+    # add channel column
+    op.add_column(
+        target_table,
+        Column("channel_id", INTEGER, ForeignKey("conda_channel.id"))
+    )
+
+    # re-add the constraint with the channel column
+    op.create_unique_constraint(
+        constraint_name="_conda_package_build_uc",
+        table_name=target_table,
+        columns=[ 
+            "channel_id",
+            "package_id",
+            "subdir",
+            "build",
+            "build_number",
+            "sha256",
+        ],
+    )

--- a/conda-store-server/conda_store_server/_internal/alembic/versions/89637f546129_remove_conda_package_build_channel.py
+++ b/conda-store-server/conda_store_server/_internal/alembic/versions/89637f546129_remove_conda_package_build_channel.py
@@ -22,8 +22,8 @@ depends_on = None
 # Due to the issue fixed in https://github.com/conda-incubator/conda-store/pull/961
 # many conda_package_build entries have the wrong package entry (but the right channel).
 # Because the packages are duplicated, we can not recreate the _conda_package_build_uc
-# constraint without the channel_id. 
-# So, this function will go thru each conda_package_build and re-associate it with the 
+# constraint without the channel_id.
+# So, this function will go thru each conda_package_build and re-associate it with the
 # correct conda_package based on the channel id.
 def fix_misrepresented_packages(conn):
     # conda_packages is a hash of channel-id_name_version to conda_package id
@@ -46,11 +46,11 @@ def fix_misrepresented_packages(conn):
 
     def get_conda_package_id(conn, channel_id, name, version):
         hashed_name = f"{channel_id}-{name}-{version}"
-        
+
         # if package exists in the conda_packages dict, return it
         if hashed_name in conda_packages:
             return conda_packages[hashed_name]
-        
+
         # if not, then query the db for the package
         package = conn.execute(
             select(conda_package_table).where(
@@ -79,7 +79,7 @@ def fix_misrepresented_packages(conn):
         # the channel_id might already be empty
         if row[2] is None:
             continue
-        
+
         package_id = get_conda_package_id(conn, row[2], row[3], row[4])
         # if found package id does not match the found package id, we'll need to updated it
         if package_id != row[1]:
@@ -107,7 +107,7 @@ def upgrade():
         # re-add the constraint without the channel column
         batch_op.create_unique_constraint(
             "_conda_package_build_uc",
-            [ 
+            [
                 "package_id",
                 "subdir",
                 "build",
@@ -139,7 +139,7 @@ def downgrade():
         # re-add the constraint with the channel column
         batch_op.create_unique_constraint(
             constraint_name="_conda_package_build_uc",
-            columns=[ 
+            columns=[
                 "channel_id",
                 "package_id",
                 "subdir",

--- a/conda-store-server/conda_store_server/_internal/orm.py
+++ b/conda-store-server/conda_store_server/_internal/orm.py
@@ -756,7 +756,6 @@ class CondaPackageBuild(Base):
 
     __table_args__ = (
         UniqueConstraint(
-            "channel_id",
             "package_id",
             "subdir",
             "build",
@@ -770,14 +769,6 @@ class CondaPackageBuild(Base):
 
     package_id: Mapped[int] = mapped_column(ForeignKey("conda_package.id"))
     package: Mapped["CondaPackage"] = relationship(back_populates="builds")
-
-    """
-    Some package builds have the exact same data from different channels.
-    Thus, when adding a channel, populating CondaPackageBuild can encounter
-    duplicate keys errors. That's why we need to distinguish them by channel_id.
-    """
-    channel_id: Mapped[int] = mapped_column(ForeignKey("conda_channel.id"))
-    channel: Mapped["CondaChannel"] = relationship(CondaChannel)
 
     build: Mapped[str] = mapped_column(Unicode(64), index=True)
     build_number: Mapped[int]

--- a/conda-store-server/environment-dev.yaml
+++ b/conda-store-server/environment-dev.yaml
@@ -22,6 +22,7 @@ dependencies:
   - pytest-celery
   - pytest-mock
   - pytest-cov
+  - pytest-alembic
   - docker-py<=7
   - docker-compose
   # build dependencies

--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -98,6 +98,7 @@ dependencies = [
   "pytest",
   "pytest-celery",
   "pytest-playwright",
+  "pytest-alembic",
   "twine>=5.0.0",
   "pkginfo>=1.10", # Needed to support metadata 2.3
   "pytest-cov",

--- a/conda-store-server/tests/_internal/alembic/__init__.py
+++ b/conda-store-server/tests/_internal/alembic/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/conda-store-server/tests/_internal/alembic/version/__init__.py
+++ b/conda-store-server/tests/_internal/alembic/version/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.

--- a/conda-store-server/tests/_internal/alembic/version/test_89637f546129_remove_conda_package_build_channel.py
+++ b/conda-store-server/tests/_internal/alembic/version/test_89637f546129_remove_conda_package_build_channel.py
@@ -1,0 +1,189 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+
+from conda_store_server import api
+from conda_store_server._internal import orm
+
+
+def setup_bad_data_db(conda_store):
+    """A database fixture populated with
+    * 2 channels
+    * 2 conda packages
+    * 5 conda package builds
+    """
+    with conda_store.session_factory() as db:
+        # create test channels
+        api.create_conda_channel(db, "test-channel-1")
+        api.create_conda_channel(db, "test-channel-2")
+        db.commit()
+
+        # create some sample conda_package's
+        # For simplicity, the channel_id's match the id of the conda_package.
+        # So, when checking that the package build entries have been reassembled
+        # the right way, check that the package_id in the conda_package_build is
+        # equal to what would have been the channel_id (before the migration is run)
+        conda_package_records = [
+            {
+                "id": 1,
+                "channel_id": 1,
+                "name": "test-package-1",
+                "version": "1.0.0",
+            },
+            {
+                "id": 2,
+                "channel_id": 2,
+                "name": "test-package-1",
+                "version": "1.0.0",
+            },
+        ]
+        for cpb in conda_package_records:
+            conda_package = orm.CondaPackage(**cpb)
+            db.add(conda_package)
+        db.commit()
+
+        # create some conda_package_build's
+        conda_package_builds = [
+            {
+                "id": 1,
+                "build": "py310h06a4308_0",
+                "package_id": 1,
+                "build_number": 0,
+                "sha256": "one",
+                "subdir": "linux-64",
+            },
+            {
+                "id": 2,
+                "build": "py311h06a4308_0",
+                "package_id": 1,
+                "build_number": 0,
+                "sha256": "two",
+                "subdir": "linux-64",
+            },
+            {
+                "id": 3,
+                "build": "py38h06a4308_0",
+                "package_id": 1,
+                "build_number": 0,
+                "sha256": "three",
+                "subdir": "linux-64",
+            },
+            {
+                "id": 4,
+                "build": "py39h06a4308_0",
+                "package_id": 2,
+                "build_number": 0,
+                "sha256": "four",
+                "subdir": "linux-64",
+            },
+            {
+                "id": 5,
+                "build": "py310h06a4308_0",
+                "package_id": 2,
+                "build_number": 0,
+                "sha256": "five",
+                "subdir": "linux-64",
+            },
+        ]
+        default_values = {
+             "depends": "",
+             "md5": "",
+             "timestamp": 0,
+             "constrains": "",
+             "size": 0,
+        }
+        for cpb in conda_package_builds:
+            conda_package = orm.CondaPackageBuild(**cpb, **default_values)
+            db.add(conda_package)
+        db.commit()
+
+        # force in some channel data
+        # conda_package_build 1 should have package_id 2 after migration
+        db.execute(text("UPDATE conda_package_build SET channel_id=2 WHERE id=1"))
+        # conda_package_build 2 should have package_id 1 after migration
+        db.execute(text("UPDATE conda_package_build SET channel_id=1 WHERE id=2"))
+        # conda_package_build 3 should have package_id 1 after migration
+        db.execute(text("UPDATE conda_package_build SET channel_id=1 WHERE id=3"))
+        # conda_package_build 4 should have package_id 2 after migration
+        db.execute(text("UPDATE conda_package_build SET channel_id=2 WHERE id=4"))
+        
+        # don't set conda_package_build 5 channel_id as a test case
+        # conda_package_build 5 package_id should be unchanged (2) after migration
+        
+        db.commit()
+
+
+def test_remove_conda_package_build_channel_basic(conda_store, alembic_config, alembic_runner):
+    """Simply run the upgrade and downgrade for this migration"""
+    # migrate all the way to the target revision
+    alembic_runner.migrate_up_to('89637f546129')
+
+    # try downgrading
+    alembic_runner.migrate_down_one()
+
+    # ensure the channel_id column exists, will error if channel_id column does not exist
+    with conda_store.session_factory() as db:
+        db.execute(text("SELECT channel_id from conda_package_build"))
+
+    # try upgrading once more
+    alembic_runner.migrate_up_one()
+
+    # ensure the channel_id column exists, will error if channel_id column does not exist
+    with conda_store.session_factory() as db:
+        with pytest.raises(OperationalError):
+            db.execute(text("SELECT channel_id from conda_package_build"))
+
+
+def test_remove_conda_package_build_bad_data(conda_store, alembic_config, alembic_runner):
+    """Simply run the upgrade and downgrade for this migration"""
+     # migrate all the way to the target revision
+    alembic_runner.migrate_up_to('89637f546129')
+    
+    # try downgrading
+    alembic_runner.migrate_down_one()
+
+    # ensure the channel_id column exists, will error if channel_id column does not exist
+    with conda_store.session_factory() as db:
+        db.execute(text("SELECT channel_id from conda_package_build"))
+
+    # seed db with data that has broken data
+    setup_bad_data_db(conda_store)
+
+    # try upgrading once more
+    alembic_runner.migrate_up_one()
+
+    # ensure the channel_id column exists, will error if channel_id column does not exist
+    with conda_store.session_factory() as db:
+        with pytest.raises(OperationalError):
+            db.execute(text("SELECT channel_id from conda_package_build"))
+
+    # ensure all packages builds have the right package associated
+    with conda_store.session_factory() as db:
+        build = db.query(orm.CondaPackageBuild).filter(
+            orm.CondaPackageBuild.id == 1
+        ).first()
+        assert build.package_id == 2
+
+        build = db.query(orm.CondaPackageBuild).filter(
+            orm.CondaPackageBuild.id == 2
+        ).first()
+        assert build.package_id == 1
+
+        build = db.query(orm.CondaPackageBuild).filter(
+            orm.CondaPackageBuild.id == 3
+        ).first()
+        assert build.package_id == 1
+
+        build = db.query(orm.CondaPackageBuild).filter(
+            orm.CondaPackageBuild.id == 4
+        ).first()
+        assert build.package_id == 2
+
+        build = db.query(orm.CondaPackageBuild).filter(
+            orm.CondaPackageBuild.id == 5
+        ).first()
+        assert build.package_id == 2

--- a/conda-store-server/tests/_internal/alembic/version/test_89637f546129_remove_conda_package_build_channel.py
+++ b/conda-store-server/tests/_internal/alembic/version/test_89637f546129_remove_conda_package_build_channel.py
@@ -90,11 +90,11 @@ def setup_bad_data_db(conda_store):
             },
         ]
         default_values = {
-             "depends": "",
-             "md5": "",
-             "timestamp": 0,
-             "constrains": "",
-             "size": 0,
+            "depends": "",
+            "md5": "",
+            "timestamp": 0,
+            "constrains": "",
+            "size": 0,
         }
         for cpb in conda_package_builds:
             conda_package = orm.CondaPackageBuild(**cpb, **default_values)
@@ -110,17 +110,19 @@ def setup_bad_data_db(conda_store):
         db.execute(text("UPDATE conda_package_build SET channel_id=1 WHERE id=3"))
         # conda_package_build 4 should have package_id 2 after migration
         db.execute(text("UPDATE conda_package_build SET channel_id=2 WHERE id=4"))
-        
+
         # don't set conda_package_build 5 channel_id as a test case
         # conda_package_build 5 package_id should be unchanged (2) after migration
-        
+
         db.commit()
 
 
-def test_remove_conda_package_build_channel_basic(conda_store, alembic_config, alembic_runner):
+def test_remove_conda_package_build_channel_basic(
+    conda_store, alembic_config, alembic_runner
+):
     """Simply run the upgrade and downgrade for this migration"""
     # migrate all the way to the target revision
-    alembic_runner.migrate_up_to('89637f546129')
+    alembic_runner.migrate_up_to("89637f546129")
 
     # try downgrading
     alembic_runner.migrate_down_one()
@@ -138,11 +140,13 @@ def test_remove_conda_package_build_channel_basic(conda_store, alembic_config, a
             db.execute(text("SELECT channel_id from conda_package_build"))
 
 
-def test_remove_conda_package_build_bad_data(conda_store, alembic_config, alembic_runner):
+def test_remove_conda_package_build_bad_data(
+    conda_store, alembic_config, alembic_runner
+):
     """Simply run the upgrade and downgrade for this migration"""
-     # migrate all the way to the target revision
-    alembic_runner.migrate_up_to('89637f546129')
-    
+    # migrate all the way to the target revision
+    alembic_runner.migrate_up_to("89637f546129")
+
     # try downgrading
     alembic_runner.migrate_down_one()
 
@@ -163,27 +167,37 @@ def test_remove_conda_package_build_bad_data(conda_store, alembic_config, alembi
 
     # ensure all packages builds have the right package associated
     with conda_store.session_factory() as db:
-        build = db.query(orm.CondaPackageBuild).filter(
-            orm.CondaPackageBuild.id == 1
-        ).first()
+        build = (
+            db.query(orm.CondaPackageBuild)
+            .filter(orm.CondaPackageBuild.id == 1)
+            .first()
+        )
         assert build.package_id == 2
 
-        build = db.query(orm.CondaPackageBuild).filter(
-            orm.CondaPackageBuild.id == 2
-        ).first()
+        build = (
+            db.query(orm.CondaPackageBuild)
+            .filter(orm.CondaPackageBuild.id == 2)
+            .first()
+        )
         assert build.package_id == 1
 
-        build = db.query(orm.CondaPackageBuild).filter(
-            orm.CondaPackageBuild.id == 3
-        ).first()
+        build = (
+            db.query(orm.CondaPackageBuild)
+            .filter(orm.CondaPackageBuild.id == 3)
+            .first()
+        )
         assert build.package_id == 1
 
-        build = db.query(orm.CondaPackageBuild).filter(
-            orm.CondaPackageBuild.id == 4
-        ).first()
+        build = (
+            db.query(orm.CondaPackageBuild)
+            .filter(orm.CondaPackageBuild.id == 4)
+            .first()
+        )
         assert build.package_id == 2
 
-        build = db.query(orm.CondaPackageBuild).filter(
-            orm.CondaPackageBuild.id == 5
-        ).first()
+        build = (
+            db.query(orm.CondaPackageBuild)
+            .filter(orm.CondaPackageBuild.id == 5)
+            .first()
+        )
         assert build.package_id == 2

--- a/conda-store-server/tests/_internal/test_orm.py
+++ b/conda-store-server/tests/_internal/test_orm.py
@@ -53,7 +53,6 @@ def populated_db(db):
             1,
             {
                 "build": "py310h06a4308_0",
-                "channel_id": 1,
                 "build_number": 0,
                 "sha256": "11f080b53b36c056dbd86ccd6dc56c40e3e70359f64279b1658bb69f91ae726f",
                 "subdir": "linux-64",
@@ -68,7 +67,6 @@ def populated_db(db):
             1,
             {
                 "build": "py311h06a4308_0",
-                "channel_id": 1,
                 "build_number": 0,
                 "sha256": "f0719ee6940402a1ea586921acfaf752fda977dbbba74407856a71ba7f6c4e4a",
                 "subdir": "linux-64",
@@ -83,7 +81,6 @@ def populated_db(db):
             1,
             {
                 "build": "py38h06a4308_0",
-                "channel_id": 1,
                 "build_number": 0,
                 "sha256": "39e39a23baebd0598c1b59ae0e82b5ffd6a3230325da4c331231d55cbcf13b3e",
                 "subdir": "linux-64",
@@ -222,8 +219,9 @@ def test_update_packages_add_existing_pkg_new_version(
     assert count == 3
     num_builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.package.channel_id == 1)
-        .all()
+        .join(orm.CondaPackage)
+        .filter(orm.CondaPackage.channel_id == 1)
+        .count()
     )
     assert num_builds == 4
     count = populated_db.query(orm.CondaPackageBuild).count()
@@ -295,7 +293,8 @@ def test_update_packages_multiple_subdirs(mock_repdata, populated_db):
     assert count == 2
     num_builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.package.channel_id == 1)
+        .join(orm.CondaPackage)
+        .filter(orm.CondaPackage.channel_id == 1)
         .count()
     )
     assert num_builds == 5
@@ -322,13 +321,15 @@ def test_update_packages_twice(mock_repdata, populated_db, test_repodata):
         assert len(conda_packages) == 1
         conda_packages = (
             populated_db.query(orm.CondaPackageBuild)
-            .filter(orm.CondaPackageBuild.package.channel_id == 1)
+            .join(orm.CondaPackage)
+            .filter(orm.CondaPackage.channel_id == 1)
             .all()
         )
         assert len(conda_packages) == 4
         conda_packages = (
             populated_db.query(orm.CondaPackageBuild)
-            .filter(orm.CondaPackageBuild.package.channel_id == 2)
+            .join(orm.CondaPackage)
+            .filter(orm.CondaPackage.channel_id == 2)
             .all()
         )
         assert len(conda_packages) == 0
@@ -369,7 +370,8 @@ def test_update_packages_new_package_channel(mock_repdata, populated_db, test_re
     assert count == 2
     num_builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.package.channel_id == 2)
+        .join(orm.CondaPackage)
+        .filter(orm.CondaPackage.channel_id == 2)
         .count()
     )
     assert num_builds == 1
@@ -401,7 +403,8 @@ def test_update_packages_multiple_builds(
     assert count == 5
     num_builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.package.channel_id == 2)
+        .join(orm.CondaPackage)
+        .filter(orm.CondaPackage.channel_id == 2)
         .count()
     )
     assert num_builds == 2

--- a/conda-store-server/tests/_internal/test_orm.py
+++ b/conda-store-server/tests/_internal/test_orm.py
@@ -222,7 +222,7 @@ def test_update_packages_add_existing_pkg_new_version(
     assert count == 3
     builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.channel_id == 1)
+        .filter(orm.CondaPackageBuild.package.channel_id == 1)
         .all()
     )
     assert len(builds) == 4
@@ -297,7 +297,7 @@ def test_update_packages_multiple_subdirs(mock_repdata, populated_db):
     assert count == 2
     builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.channel_id == 1)
+        .filter(orm.CondaPackageBuild.package.channel_id == 1)
         .all()
     )
     assert len(builds) == 5
@@ -326,13 +326,13 @@ def test_update_packages_twice(mock_repdata, populated_db, test_repodata):
         assert len(conda_packages) == 1
         conda_packages = (
             populated_db.query(orm.CondaPackageBuild)
-            .filter(orm.CondaPackageBuild.channel_id == 1)
+            .filter(orm.CondaPackageBuild.package.channel_id == 1)
             .all()
         )
         assert len(conda_packages) == 4
         conda_packages = (
             populated_db.query(orm.CondaPackageBuild)
-            .filter(orm.CondaPackageBuild.channel_id == 2)
+            .filter(orm.CondaPackageBuild.package.channel_id == 2)
             .all()
         )
         assert len(conda_packages) == 0
@@ -373,7 +373,7 @@ def test_update_packages_new_package_channel(mock_repdata, populated_db, test_re
     assert count == 2
     builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.channel_id == 2)
+        .filter(orm.CondaPackageBuild.package.channel_id == 2)
         .all()
     )
     assert len(builds) == 1
@@ -407,7 +407,7 @@ def test_update_packages_multiple_builds(
     assert count == 5
     builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.channel_id == 2)
+        .filter(orm.CondaPackageBuild.package.channel_id == 2)
         .all()
     )
     assert len(builds) == 2
@@ -429,7 +429,7 @@ def test_update_packages_channel_consistency(
     # ensure the package builds end up with the correct channel
     builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.channel_id == 2)
+        .filter(orm.CondaPackageBuild.package.channel_id == 2)
         .all()
     )
     for b in builds:
@@ -445,7 +445,7 @@ def test_update_packages_channel_consistency(
     # ensure the package builds end up with the correct channel
     builds = (
         populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.channel_id == 1)
+        .filter(orm.CondaPackageBuild.package.channel_id == 1)
         .all()
     )
     for b in builds:

--- a/conda-store-server/tests/_internal/test_orm.py
+++ b/conda-store-server/tests/_internal/test_orm.py
@@ -220,14 +220,12 @@ def test_update_packages_add_existing_pkg_new_version(
     assert count == 2
     count = populated_db.query(orm.CondaPackage).count()
     assert count == 3
-    builds = (
+    num_builds = (
         populated_db.query(orm.CondaPackageBuild)
         .filter(orm.CondaPackageBuild.package.channel_id == 1)
         .all()
     )
-    assert len(builds) == 4
-    for b in builds:
-        assert b.package.channel_id == 1
+    assert num_builds == 4
     count = populated_db.query(orm.CondaPackageBuild).count()
     assert count == 4
 
@@ -295,14 +293,12 @@ def test_update_packages_multiple_subdirs(mock_repdata, populated_db):
         .count()
     )
     assert count == 2
-    builds = (
+    num_builds = (
         populated_db.query(orm.CondaPackageBuild)
         .filter(orm.CondaPackageBuild.package.channel_id == 1)
-        .all()
+        .count()
     )
-    assert len(builds) == 5
-    for b in builds:
-        assert b.package.channel_id == 1
+    assert num_builds == 5
 
 
 @mock.patch("conda_store_server._internal.conda_utils.download_repodata")
@@ -371,14 +367,12 @@ def test_update_packages_new_package_channel(mock_repdata, populated_db, test_re
         .count()
     )
     assert count == 2
-    builds = (
+    num_builds = (
         populated_db.query(orm.CondaPackageBuild)
         .filter(orm.CondaPackageBuild.package.channel_id == 2)
-        .all()
+        .count()
     )
-    assert len(builds) == 1
-    for b in builds:
-        assert b.package.channel_id == 2
+    assert num_builds == 1
     count = populated_db.query(orm.CondaPackageBuild).count()
     assert count == 4
 
@@ -405,49 +399,9 @@ def test_update_packages_multiple_builds(
     # ensure it is added to conda package builds
     count = populated_db.query(orm.CondaPackageBuild).count()
     assert count == 5
-    builds = (
+    num_builds = (
         populated_db.query(orm.CondaPackageBuild)
         .filter(orm.CondaPackageBuild.package.channel_id == 2)
-        .all()
+        .count()
     )
-    assert len(builds) == 2
-    for b in builds:
-        assert b.package.channel_id == 2
-
-
-@mock.patch("conda_store_server._internal.conda_utils.download_repodata")
-def test_update_packages_channel_consistency(
-    mock_repdata, populated_db, test_repodata_multiple_packages
-):
-    mock_repdata.return_value = test_repodata_multiple_packages
-
-    channel = (
-        populated_db.query(orm.CondaChannel).filter(orm.CondaChannel.id == 2).first()
-    )
-    channel.update_packages(populated_db, "linux-64")
-
-    # ensure the package builds end up with the correct channel
-    builds = (
-        populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.package.channel_id == 2)
-        .all()
-    )
-    for b in builds:
-        assert b.channel_id == 2
-        assert b.package.channel_id == 2
-
-    # again with another channel
-    channel = (
-        populated_db.query(orm.CondaChannel).filter(orm.CondaChannel.id == 1).first()
-    )
-    channel.update_packages(populated_db, "linux-64")
-
-    # ensure the package builds end up with the correct channel
-    builds = (
-        populated_db.query(orm.CondaPackageBuild)
-        .filter(orm.CondaPackageBuild.package.channel_id == 1)
-        .all()
-    )
-    for b in builds:
-        assert b.channel_id == 1
-        assert b.package.channel_id == 1
+    assert num_builds == 2

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+from pytest_alembic.config import Config
 
 from conda_store_server import api, app, storage
 
@@ -288,6 +289,14 @@ def plugin_manager():
     pm = PluginManager(hookspec.spec_name)
     pm.add_hookspecs(hookspec.CondaStoreSpecs)
     return pm
+
+
+@pytest.fixture
+def alembic_config(conda_store):
+     from conda_store_server._internal.dbutil import ALEMBIC_DIR, write_alembic_ini
+     ini_file = pathlib.Path(__file__).parent / "alembic.ini"
+     write_alembic_ini(ini_file, conda_store.database_url)
+     return {"file": ini_file}
 
 
 def _seed_conda_store(

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -13,7 +13,6 @@ import pytest
 import yaml
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
-from pytest_alembic.config import Config
 
 from conda_store_server import api, app, storage
 
@@ -293,10 +292,11 @@ def plugin_manager():
 
 @pytest.fixture
 def alembic_config(conda_store):
-     from conda_store_server._internal.dbutil import ALEMBIC_DIR, write_alembic_ini
-     ini_file = pathlib.Path(__file__).parent / "alembic.ini"
-     write_alembic_ini(ini_file, conda_store.database_url)
-     return {"file": ini_file}
+    from conda_store_server._internal.dbutil import write_alembic_ini
+
+    ini_file = pathlib.Path(__file__).parent / "alembic.ini"
+    write_alembic_ini(ini_file, conda_store.database_url)
+    return {"file": ini_file}
 
 
 def _seed_conda_store(

--- a/docusaurus-docs/conda-store/references/database.md
+++ b/docusaurus-docs/conda-store/references/database.md
@@ -46,7 +46,7 @@ conda-store relies on [SQLAlchemy](https://www.sqlalchemy.org/) for ORM mapping,
 The procedure to modify the database is the following :
 
 - First, modify [the ORM Model](https://github.com/conda-incubator/conda-store/blob/main/conda-store-server/conda_store_server/orm.py) according to the changes you want to make
-- edit the file `conda-store-server/alembic.ini` and replace the value for entry `sqlalchemy.url` to match the connection URL of your database.
+- edit the file `conda-store-server/conda_store_server/_internal/alembic.ini` and replace the value for entry `sqlalchemy.url` to match the connection URL of your database.
 
 For example (when postgres was started via Docker compose):
 ```
@@ -57,7 +57,7 @@ sqlalchemy.url = postgresql+psycopg2://postgres:password@localhost:5432/conda-st
 - in your command line, run the following :
 
 ```sh
-cd conda-store-server/conda_store_server
+cd conda-store-server/conda_store_server/_internal
 alembic revision --autogenerate -m "description of your changes"
 ```
 


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/994

## Description

The primary focus of this pr is to remove the `channel_id` column and `channel` association in the `conda_package_build` table. This is redundant information, also available in the associated `package`. In order to get channel information from a `conda_package_build` users may join the `conda_package` table and `conda_package_build` table. For example:
```
from conda_store_server._internal import orm

db.query(orm.CondaPackageBuild)
        .join(orm.CondaPackage)
        .filter(orm.CondaPackage.channel_id == 1)
```

Things changed in this PR:
* removal of the `channel_id` column in the `conda_package_build` table
* a migration script. It does 2 things:
  *  updates the `conda_package_build` to have the correct package associated with each row. See #961 for more details about this issue
  * updates the database table column + unique constraint
* updates the docs for how to write a migration
* adds a dependency on [pytest-alembic
](https://pytest-alembic.readthedocs.io/en/latest/running.html)
* sets up running tests for alembic migrations

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional Info

Part of the migration is to correct some of the conda_package_build entries that have the wrong conda_package associated with them. Since this needs to sort thru all elements of this table, this migration takes a while to run. Users should probably opt to run this migration directly with alembic.
