### PR TITLE
Fix conda_package_build "build" column type

### DIFF
--- a/conda-store-server/conda_store_server/_internal/orm.py
+++ b/conda-store-server/conda_store_server/_internal/orm.py
@@ -786,7 +786,7 @@ class CondaPackageBuild(Base):
     channel_id: Mapped[int] = mapped_column(ForeignKey("conda_channel.id"))
     channel: Mapped["CondaChannel"] = relationship(CondaChannel)
 
-    build: Mapped[int] = mapped_column(Unicode(64), index=True)
+    build: Mapped[str] = mapped_column(Unicode(64), index=True)
     build_number: Mapped[int]
     constrains: Mapped[dict] = mapped_column(JSON)
     depends: Mapped[dict] = mapped_column(JSON)


### PR DESCRIPTION
## Description

This should be a string instead of an int, for example "py310h06a4308_0". This was probably updated to the wrong type by accident as part of https://github.com/conda-incubator/conda-store/pull/970



## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

