### PR TITLE
Deprecate docker registry

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -84,7 +84,7 @@ class CondaStoreServer(Application):
     )
 
     enable_registry = Bool(
-        True, help="enable the docker registry for conda-store", config=True
+        False, help="enable the docker registry for conda-store", config=True
     )
 
     enable_metrics = Bool(

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -84,7 +84,7 @@ class CondaStoreServer(Application):
     )
 
     enable_registry = Bool(
-        False, help="enable the docker registry for conda-store", config=True
+        False, help="(deprecated) enable the docker registry for conda-store", config=True
     )
 
     enable_metrics = Bool(
@@ -101,7 +101,7 @@ class CondaStoreServer(Application):
 
     registry_external_url = Unicode(
         "localhost:8080",
-        help='external hostname and port to access docker registry cannot contain "http://" or "https://"',
+        help='(deprecated) external hostname and port to access docker registry cannot contain "http://" or "https://"',
         config=True,
     )
 

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -84,7 +84,9 @@ class CondaStoreServer(Application):
     )
 
     enable_registry = Bool(
-        False, help="(deprecated) enable the docker registry for conda-store", config=True
+        False,
+        help="(deprecated) enable the docker registry for conda-store",
+        config=True,
     )
 
     enable_metrics = Bool(

--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -3,14 +3,14 @@
 # license that can be found in the LICENSE file.
 
 import datetime
-from typing import Any, Dict, List, Optional, Callable
+from functools import wraps
+from typing import Any, Callable, Dict, List, Optional
 
 import pydantic
 import yaml
 from celery.result import AsyncResult
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, RedirectResponse
-from functools import wraps
 
 from conda_store_server import __version__, api
 from conda_store_server._internal import orm, schema
@@ -105,6 +105,7 @@ def paginated_api_response(
         "count": count,
     }
 
+
 def deprecated(sunset_date: datetime.date) -> Callable:
     """Decorator to add deprecation headers to a HTTP response. These will include:
         {
@@ -120,14 +121,19 @@ def deprecated(sunset_date: datetime.date) -> Callable:
     sunset_date : datetime.date
         the date that the endpoint will have it's functionality removed
     """
+
     def decorator(func):
         @wraps(func)
         def add_deprecated_headers(*args, **kwargs):
             response = func(*args, **kwargs)
             response.headers["Deprecation"] = "True"
-            response.headers["Sunset"] = sunset_date.strftime("%a, %d %b %Y 00:00:00 UTC")
+            response.headers["Sunset"] = sunset_date.strftime(
+                "%a, %d %b %Y 00:00:00 UTC"
+            )
             return response
+
         return add_deprecated_headers
+
     return decorator
 
 
@@ -1380,7 +1386,8 @@ async def api_get_build_docker_image_url(
                 "message": f"Build {build_id} doesn't have a docker manifest",
             }
             return JSONResponse(
-                status_code=400, content=content,
+                status_code=400,
+                content=content,
             )
 
 

--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -1353,7 +1353,7 @@ async def api_get_build_archive(
 
 
 @router_api.get("/build/{build_id}/docker/", deprecated=True)
-@deprecated(sunset_date=datetime.date(2025, 2, 17))
+@deprecated(sunset_date=datetime.date(2025, 3, 17))
 async def api_get_build_docker_image_url(
     build_id: int,
     request: Request,

--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Callable
 
 import pydantic
 import yaml
@@ -105,14 +105,14 @@ def paginated_api_response(
         "count": count,
     }
 
-def deprecated(sunset_date: datetime.date):
+def deprecated(sunset_date: datetime.date) -> Callable:
     """Decorator to add deprecation headers to a HTTP response. These will include:
         {
             Deprecation: True
             Sunset: <sunset_date>
         }
 
-    See the conda-store backwards compatibility policy for appropriate use of 
+    See the conda-store backwards compatibility policy for appropriate use of
     deprecations https://conda.store/community/policies/backwards-compatibility.
 
     Parameters

--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -105,22 +105,27 @@ def paginated_api_response(
         "count": count,
     }
 
-def deprecated(sunset_date):
-    """
-    Decorator to add deprecation headers to a response. These will include
+def deprecated(sunset_date: datetime.date):
+    """Decorator to add deprecation headers to a HTTP response. These will include:
         {
             Deprecation: True
             Sunset: <sunset_date>
         }
 
-    :param sunset_date: the sunset date in HTTP-Date format, for example "Mon, 16 Feb 2025 23:59:59 UTC"
+    See the conda-store backwards compatibility policy for appropriate use of 
+    deprecations https://conda.store/community/policies/backwards-compatibility.
+
+    Parameters
+    ----------
+    sunset_date : datetime.date
+        the date that the endpoint will have it's functionality removed
     """
     def decorator(func):
         @wraps(func)
         def add_deprecated_headers(*args, **kwargs):
             response = func(*args, **kwargs)
             response.headers["Deprecation"] = "True"
-            response.headers["Sunset"] = sunset_date
+            response.headers["Sunset"] = sunset_date.strftime("%a, %d %b %Y 00:00:00 UTC")
             return response
         return add_deprecated_headers
     return decorator
@@ -1348,7 +1353,7 @@ async def api_get_build_archive(
 
 
 @router_api.get("/build/{build_id}/docker/", deprecated=True)
-@deprecated(sunset_date="Mon, 16 Feb 2025 23:59:59 UTC")
+@deprecated(sunset_date=datetime.date(2025, 2, 17))
 async def api_get_build_docker_image_url(
     build_id: int,
     request: Request,

--- a/conda-store-server/conda_store_server/_internal/server/views/registry.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/registry.py
@@ -2,17 +2,17 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import datetime
 import json
 import time
-import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse, Response
 
 from conda_store_server import api
-from conda_store_server._internal.server.views.api import deprecated
 from conda_store_server._internal import orm, schema
 from conda_store_server._internal.server import dependencies
+from conda_store_server._internal.server.views.api import deprecated
 from conda_store_server.server.schema import Permissions
 
 router_registry = APIRouter(tags=["registry"])
@@ -78,6 +78,7 @@ def dynamic_conda_store_environment(conda_store, packages):
         )
     return environment_name
 
+
 @deprecated(sunset_date=datetime.date(2025, 3, 17))
 def get_docker_image_manifest(conda_store, image, tag, timeout=10 * 60):
     namespace, *image_name = image.split("/")
@@ -134,6 +135,7 @@ def get_docker_image_blob(conda_store, image, blobsum):
     blob_key = f"docker/blobs/{blobsum}"
     return RedirectResponse(conda_store.storage.get_url(blob_key))
 
+
 @router_registry.get("/v2/", deprecated=True)
 @deprecated(sunset_date=datetime.date(2025, 3, 17))
 def v2(
@@ -146,9 +148,7 @@ def v2(
     return _json_response({})
 
 
-@router_registry.get(
-    "/v2/{rest:path}", deprecated=True
-)
+@router_registry.get("/v2/{rest:path}", deprecated=True)
 @deprecated(sunset_date=datetime.date(2025, 3, 17))
 def list_tags(
     rest: str,

--- a/conda-store-server/conda_store_server/_internal/server/views/registry.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/registry.py
@@ -78,7 +78,7 @@ def dynamic_conda_store_environment(conda_store, packages):
         )
     return environment_name
 
-@deprecated(sunset_date=datetime.date(2025, 2, 17))
+@deprecated(sunset_date=datetime.date(2025, 3, 17))
 def get_docker_image_manifest(conda_store, image, tag, timeout=10 * 60):
     namespace, *image_name = image.split("/")
 
@@ -129,13 +129,13 @@ def get_docker_image_manifest(conda_store, image, tag, timeout=10 * 60):
     return RedirectResponse(conda_store.storage.get_url(manifests_key))
 
 
-@deprecated(sunset_date=datetime.date(2025, 2, 17))
+@deprecated(sunset_date=datetime.date(2025, 3, 17))
 def get_docker_image_blob(conda_store, image, blobsum):
     blob_key = f"docker/blobs/{blobsum}"
     return RedirectResponse(conda_store.storage.get_url(blob_key))
 
 @router_registry.get("/v2/", deprecated=True)
-@deprecated(sunset_date=datetime.date(2025, 2, 17))
+@deprecated(sunset_date=datetime.date(2025, 3, 17))
 def v2(
     request: Request,
     entity=Depends(dependencies.get_entity),
@@ -149,7 +149,7 @@ def v2(
 @router_registry.get(
     "/v2/{rest:path}", deprecated=True
 )
-@deprecated(sunset_date=datetime.date(2025, 2, 17))
+@deprecated(sunset_date=datetime.date(2025, 3, 17))
 def list_tags(
     rest: str,
     request: Request,

--- a/conda-store-server/conda_store_server/_internal/server/views/registry.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/registry.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse, Response
 
 from conda_store_server import api
+from conda_store_server._internal.server.views.api import deprecated
 from conda_store_server._internal import orm, schema
 from conda_store_server._internal.server import dependencies
 from conda_store_server.server.schema import Permissions
@@ -21,8 +22,6 @@ def _json_response(data, status=200, mimetype="application/json"):
         content=json.dumps(data, indent=3), status_code=status, media_type=mimetype
     )
     response.headers["Docker-Distribution-Api-Version"] = "registry/2.0"
-    response.headers["Deprecation"] = "True"
-    response.headers["Sunset"] = "Mon, 16 Feb 2025 23:59:59 UTC"
     return response
 
 
@@ -78,10 +77,9 @@ def dynamic_conda_store_environment(conda_store, packages):
         )
     return environment_name
 
-
+@deprecated(sunset_date="Mon, 16 Feb 2025 23:59:59 UTC")
 def get_docker_image_manifest(conda_store, image, tag, timeout=10 * 60):
     namespace, *image_name = image.split("/")
-    response_headers = {"Deprecation": "True", "Sunset": "Mon, 16 Feb 2025 23:59:59 UTC"}
 
     # /v2/<image-name>/manifest/<tag>
     if len(image_name) == 0:
@@ -106,7 +104,7 @@ def get_docker_image_manifest(conda_store, image, tag, timeout=10 * 60):
     elif tag.startswith("sha256:"):
         # looking for sha256 of docker manifest
         manifests_key = f"docker/manifest/{tag}"
-        return RedirectResponse(conda_store.storage.get_url(manifests_key), response_headers=response_headers)
+        return RedirectResponse(conda_store.storage.get_url(manifests_key))
     else:
         build_key = tag
 
@@ -127,16 +125,16 @@ def get_docker_image_manifest(conda_store, image, tag, timeout=10 * 60):
             return docker_error_message(schema.DockerRegistryError.MANIFEST_UNKNOWN)
 
     manifests_key = f"docker/manifest/{build_key}"
-    return RedirectResponse(conda_store.storage.get_url(manifests_key), response_headers=response_headers)
+    return RedirectResponse(conda_store.storage.get_url(manifests_key))
 
 
+@deprecated(sunset_date="Mon, 16 Feb 2025 23:59:59 UTC")
 def get_docker_image_blob(conda_store, image, blobsum):
     blob_key = f"docker/blobs/{blobsum}"
-    response_headers = {"Deprecation": "True", "Sunset": "Mon, 16 Feb 2025 23:59:59 UTC"}
-    return RedirectResponse(conda_store.storage.get_url(blob_key), response_headers=response_headers)
-
+    return RedirectResponse(conda_store.storage.get_url(blob_key))
 
 @router_registry.get("/v2/", deprecated=True)
+@deprecated(sunset_date="Mon, 16 Feb 2025 23:59:59 UTC")
 def v2(
     request: Request,
     entity=Depends(dependencies.get_entity),
@@ -150,6 +148,7 @@ def v2(
 @router_registry.get(
     "/v2/{rest:path}", deprecated=True
 )
+@deprecated(sunset_date="Mon, 16 Feb 2025 23:59:59 UTC")
 def list_tags(
     rest: str,
     request: Request,

--- a/conda-store-server/conda_store_server/_internal/server/views/registry.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/registry.py
@@ -4,6 +4,7 @@
 
 import json
 import time
+import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse, Response
@@ -77,7 +78,7 @@ def dynamic_conda_store_environment(conda_store, packages):
         )
     return environment_name
 
-@deprecated(sunset_date="Mon, 16 Feb 2025 23:59:59 UTC")
+@deprecated(sunset_date=datetime.date(2025, 2, 17))
 def get_docker_image_manifest(conda_store, image, tag, timeout=10 * 60):
     namespace, *image_name = image.split("/")
 
@@ -128,13 +129,13 @@ def get_docker_image_manifest(conda_store, image, tag, timeout=10 * 60):
     return RedirectResponse(conda_store.storage.get_url(manifests_key))
 
 
-@deprecated(sunset_date="Mon, 16 Feb 2025 23:59:59 UTC")
+@deprecated(sunset_date=datetime.date(2025, 2, 17))
 def get_docker_image_blob(conda_store, image, blobsum):
     blob_key = f"docker/blobs/{blobsum}"
     return RedirectResponse(conda_store.storage.get_url(blob_key))
 
 @router_registry.get("/v2/", deprecated=True)
-@deprecated(sunset_date="Mon, 16 Feb 2025 23:59:59 UTC")
+@deprecated(sunset_date=datetime.date(2025, 2, 17))
 def v2(
     request: Request,
     entity=Depends(dependencies.get_entity),
@@ -148,7 +149,7 @@ def v2(
 @router_registry.get(
     "/v2/{rest:path}", deprecated=True
 )
-@deprecated(sunset_date="Mon, 16 Feb 2025 23:59:59 UTC")
+@deprecated(sunset_date=datetime.date(2025, 2, 17))
 def list_tags(
     rest: str,
     request: Request,

--- a/conda-store-server/tests/_internal/server/views/test_api.py
+++ b/conda-store-server/tests/_internal/server/views/test_api.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 import time
+import datetime
 
 import httpx
 import pytest
@@ -44,6 +45,21 @@ def mock_entity_role_bindings(
     yield
 
     testclient.app.dependency_overrides = {}
+
+
+def test_deprecation_warning():
+    from fastapi.responses import JSONResponse
+    from conda_store_server._internal.server.views.api import deprecated
+
+    @deprecated(datetime.date(2024, 12, 17))
+    def api_status():
+        return JSONResponse(
+                status_code=400, content={"ok": "ok"},
+            )
+    
+    result = api_status()
+    assert(result.headers.get("Deprecation") == "True")
+    assert(result.headers.get("Sunset") == "Tue, 17 Dec 2024 00:00:00 UTC")
 
 
 def test_api_version_unauth(testclient):

--- a/conda-store-server/tests/_internal/server/views/test_api.py
+++ b/conda-store-server/tests/_internal/server/views/test_api.py
@@ -3,11 +3,11 @@
 # license that can be found in the LICENSE file.
 
 import contextlib
+import datetime
 import json
 import os
 import sys
 import time
-import datetime
 
 import httpx
 import pytest
@@ -49,17 +49,19 @@ def mock_entity_role_bindings(
 
 def test_deprecation_warning():
     from fastapi.responses import JSONResponse
+
     from conda_store_server._internal.server.views.api import deprecated
 
     @deprecated(datetime.date(2024, 12, 17))
     def api_status():
         return JSONResponse(
-                status_code=400, content={"ok": "ok"},
-            )
-    
+            status_code=400,
+            content={"ok": "ok"},
+        )
+
     result = api_status()
-    assert(result.headers.get("Deprecation") == "True")
-    assert(result.headers.get("Sunset") == "Tue, 17 Dec 2024 00:00:00 UTC")
+    assert result.headers.get("Deprecation") == "True"
+    assert result.headers.get("Sunset") == "Tue, 17 Dec 2024 00:00:00 UTC"
 
 
 def test_api_version_unauth(testclient):

--- a/docusaurus-docs/conda-store/explanations/artifacts.md
+++ b/docusaurus-docs/conda-store/explanations/artifacts.md
@@ -65,8 +65,9 @@ To install the tarball, follow the [instructions for the target machine in the c
 
 ## Docker images (deprecated)
 
-:::warning
-Docker image creation is currently not supported.
+:::warning[Deprecation notice]
+Docker image creation is currently not supported. This feature is scheduled to be 
+removed March 17, 2025.
 :::
 
 ### Authentication

--- a/docusaurus-docs/conda-store/explanations/artifacts.md
+++ b/docusaurus-docs/conda-store/explanations/artifacts.md
@@ -63,7 +63,7 @@ Click **"Download archive"** button to download the archive of your conda enviro
 
 To install the tarball, follow the [instructions for the target machine in the conda-pack documentation][conda-pack-usage].
 
-## Docker images
+## Docker images (deprecated)
 
 :::warning
 Docker image creation is currently not supported.

--- a/docusaurus-docs/conda-store/explanations/artifacts.md
+++ b/docusaurus-docs/conda-store/explanations/artifacts.md
@@ -66,7 +66,7 @@ To install the tarball, follow the [instructions for the target machine in the c
 ## Docker images (deprecated)
 
 :::warning[Deprecation notice]
-Docker image creation is currently not supported. This feature is scheduled to be 
+Docker image creation is currently not supported. This feature is scheduled to be
 removed March 17, 2025.
 :::
 

--- a/docusaurus-docs/conda-store/references/configuration-options.md
+++ b/docusaurus-docs/conda-store/references/configuration-options.md
@@ -210,13 +210,15 @@ setting is useful if you want to protect environments from
 modification from certain users and groups. Note: this configuration
 option is not supported on Windows.
 
-`CondaStore.serialize_builds` DEPRECATED no longer has any effect
-
 `CondaStore.post_update_environment_build_hook` is an optional configurable to
 allow for custom behavior that will run after an environment's current build changes.
 
 `CondaStore.lock_backend` is the name of the default lock plugin to use
 when locking a conda environment. By default, conda-store uses [conda-lock](https://github.com/conda/conda-lock).
+
+#### Deprecated configuration options for `conda_store_server._internal.app.CondaStore`
+
+`CondaStore.serialize_builds` no longer has any effect
 
 ### `conda_store_server.storage.S3Storage`
 
@@ -305,7 +307,9 @@ bindings that an authenticated user assumes.
 `Authentication.cookie_name` is the name for the browser cookie used
 to authenticate users.
 
-`Authentication.cookie_domain` use when wanting to set a subdomain wide cookie. For example setting this to `example.com` would allow the cookie to be valid for `example.com` along with `*.example.com`.
+`Authentication.cookie_domain` use when wanting to set a subdomain wide 
+cookie. For example setting this to `example.com` would allow the cookie 
+to be valid for `example.com` along with `*.example.com`.
 
 `Authentication.authentication_backend` is the class to use for
 authentication logic. The default is `AuthenticationBackend` and will
@@ -441,8 +445,6 @@ endpoints. Default True.
 `CondaStoreServer.enable_api` a Boolean on whether to expose the API
 endpoints. Default True.
 
-`CondaStoreServer.enable_registry` (deprecated) a Boolean on whether to expose the registry endpoints. Default False.
-
 `CondaStoreServer.enable_metrics` a Boolean on whether to expose the
 metrics endpoints. Default True.
 
@@ -451,9 +453,6 @@ to. The default is all IP addresses `0.0.0.0`.
 
 `CondaStoreServer.port` is the port for conda-store server to
 use. Default is `8080`.
-
-`CondaStoreServer.registry_external_url` (deprecated) is the external hostname and
-port to access docker registry cannot contain `http://` or `https://`.
 
 `CondaStoreServer.url_prefix` is the prefix URL (subdirectory) for the
 entire application. All but the registry routes obey this. This is due
@@ -485,7 +484,15 @@ to serve in form `[(path, method, function), ...]`. `path` is a
 string, `method` is `get`, `post`, `put`, `delete` etc. and function
 is a regular python fastapi function.
 
-### `conda_store_server.._internal.worker.app.CondaStoreWorker`
+#### Deprecated configuration options for `conda_store_server._internal.server.app.CondaStoreServer`
+
+`CondaStoreServer.enable_registry` (deprecated) a Boolean on whether to 
+expose the registry endpoints. Default False.
+
+`CondaStoreServer.registry_external_url` (deprecated) is the external hostname 
+and port to access docker registry cannot contain `http://` or `https://`.
+
+### `conda_store_server._internal.worker.app.CondaStoreWorker`
 
 `CondaStoreWorker.log_level` is the level for all server
 logging. Default is `INFO`. Common options are `DEBUG`, `INFO`,

--- a/docusaurus-docs/conda-store/references/configuration-options.md
+++ b/docusaurus-docs/conda-store/references/configuration-options.md
@@ -4,7 +4,7 @@ description: conda-store configuration options
 
 # Configuration options
 
-### Traitlets
+## Traitlets
 
 :::warning
 This page is in active development, content may be inaccurate and incomplete.
@@ -24,7 +24,7 @@ conda-store-server --config <path-to-conda-store-config.py>
 conda-store-worker --config <path-to-conda-store-config.py>
 ```
 
-### Data directory
+## Data directory
 
 The `CONDA_STORE_DIR` Python variable specifies the conda-store data directory,
 which is used by some of the configuration options mentioned below, like
@@ -49,7 +49,7 @@ Please use the conda-store configuration options mentioned below instead.
 
 [platformdirs]: https://github.com/platformdirs/platformdirs
 
-### `conda_store_server._internal.app.CondaStore`
+## `conda_store_server._internal.app.CondaStore`
 
 `CondaStore.storage_class` configures the storage backend to use for
 storing build artifacts from
@@ -216,11 +216,11 @@ allow for custom behavior that will run after an environment's current build cha
 `CondaStore.lock_backend` is the name of the default lock plugin to use
 when locking a conda environment. By default, conda-store uses [conda-lock](https://github.com/conda/conda-lock).
 
-#### Deprecated configuration options for `conda_store_server._internal.app.CondaStore`
+### Deprecated configuration options for `conda_store_server._internal.app.CondaStore`
 
 `CondaStore.serialize_builds` no longer has any effect
 
-### `conda_store_server.storage.S3Storage`
+## `conda_store_server.storage.S3Storage`
 
 conda-store uses [minio-py](https://github.com/minio/minio-py) as a
 client to connect to S3 "like" object stores.
@@ -266,7 +266,7 @@ credentials class.
 `S3Storage.credentials_kwargs` keyword arguments to pass for creation
 of credentials class.
 
-### `conda_store_server.storage.LocalStorage`
+## `conda_store_server.storage.LocalStorage`
 
 `LocalStorage.storage_path` is the base directory to use for storing
 build artifacts.
@@ -275,7 +275,7 @@ build artifacts.
 artifacts. This url assumes that the base will be a static server
 serving `LocalStorage.storage_path`.
 
-### `conda_store_server.server.auth.AuthenticationBackend`
+## `conda_store_server.server.auth.AuthenticationBackend`
 
 `AuthenticationBackend.secret` is the symmetric secret to use for
 encrypting tokens.
@@ -289,7 +289,7 @@ in a similar manner to how things are done with jupyterhub. Format for
 the values is a dictionary with keys being the tokens and values being
 the `schema.AuthenticaitonToken` all fields are optional.
 
-### `conda_store_server.server.auth.AuthorizationBackend`
+## `conda_store_server.server.auth.AuthorizationBackend`
 
 `AuthorizationBackend.role_mappings` is a dictionary that maps `roles`
 to application `permissions`. There are three default roles at the
@@ -302,7 +302,7 @@ bindings that an unauthenticated user assumes.
 `AuthorizationBackend.authenticated_role_bindings` are the base role
 bindings that an authenticated user assumes.
 
-### `conda_store_server.server.auth.Authentication`
+## `conda_store_server.server.auth.Authentication`
 
 `Authentication.cookie_name` is the name for the browser cookie used
 to authenticate users.
@@ -322,7 +322,7 @@ likely not need to change.
 `Authentication.login_html` is the HTML to display for a given user as
 the login form.
 
-### `conda_store_server.server.auth.DummyAuthentication`
+## `conda_store_server.server.auth.DummyAuthentication`
 
 Has all the configuration settings of `Authetication`. This class is
 modeled after the [JupyterHub DummyAuthentication
@@ -332,7 +332,7 @@ class](https://github.com/jupyterhub/jupyterhub/blob/9f3663769e96d2e4f665fd6ef48
 login with. Effectively a static password. This rarely if ever should
 be used outside of testing.
 
-### `conda_store_server.server.auth.GenericOAuthAuthentication`
+## `conda_store_server.server.auth.GenericOAuthAuthentication`
 
 A provider-agnostic OAuth authentication provider. Configure
 endpoints, secrets and other parameters to enable any OAuth-compatible
@@ -369,7 +369,7 @@ especially useful when web service is behind a proxy.
 `GenericOAuthAuthentication.tls_verify` to optionally turn of TLS
 verification useful for custom signed certificates.
 
-### `conda_store_server.server.auth.GithubOAuthAuthentication`
+## `conda_store_server.server.auth.GithubOAuthAuthentication`
 
 Inherits from `Authentication` and `GenericOAuthAuthentication` so
 should be fully configurable from those options.
@@ -380,7 +380,7 @@ is `https://github.com`.
 `GithubOAuthAuthentication.github_api` is the REST API url for
 GitHub. Default is `https://api.github.com`.
 
-### `conda_store_server.server.auth.JupyterHubOAuthAuthentication`
+## `conda_store_server.server.auth.JupyterHubOAuthAuthentication`
 
 Inherits from `Authentication` and `GenericOAuthAuthentication` so
 should be fully configurable from those options.
@@ -388,7 +388,7 @@ should be fully configurable from those options.
 `GithubOAuthAuthentication.jupyterhub_url` is the url for connecting
 to JupyterHub. The URL should not include the `/hub/`.
 
-### `conda_store_server.server.auth.RBACAuthorizationBackend`
+## `conda_store_server.server.auth.RBACAuthorizationBackend`
 
 `RBACAuthorizationBackend.role_mappings_version` specifies the role mappings
 version to use: 1 (default, legacy), 2 (new, recommended).
@@ -433,7 +433,7 @@ metadata and set the roles:
 PUT /api/v1/namespace/{namespace}/
 ```
 
-### `conda_store_server._internal.server.app.CondaStoreServer`
+## `conda_store_server._internal.server.app.CondaStoreServer`
 
 `CondaStoreServer.log_level` is the level for all server
 logging. Default is `INFO`. Common options are `DEBUG`, `INFO`,
@@ -484,7 +484,7 @@ to serve in form `[(path, method, function), ...]`. `path` is a
 string, `method` is `get`, `post`, `put`, `delete` etc. and function
 is a regular python fastapi function.
 
-#### Deprecated configuration options for `conda_store_server._internal.server.app.CondaStoreServer`
+### Deprecated configuration options for `conda_store_server._internal.server.app.CondaStoreServer`
 
 `CondaStoreServer.enable_registry` (deprecated) a Boolean on whether to 
 expose the registry endpoints. Default False.
@@ -492,7 +492,7 @@ expose the registry endpoints. Default False.
 `CondaStoreServer.registry_external_url` (deprecated) is the external hostname 
 and port to access docker registry cannot contain `http://` or `https://`.
 
-### `conda_store_server._internal.worker.app.CondaStoreWorker`
+## `conda_store_server._internal.worker.app.CondaStoreWorker`
 
 `CondaStoreWorker.log_level` is the level for all server
 logging. Default is `INFO`. Common options are `DEBUG`, `INFO`,
@@ -506,6 +506,6 @@ single filename to watch.
 the number of threads on your given machine. If set will limit the
 number of concurrent celery tasks to the integer.
 
-### (deprecated) `conda_store_server.registry.ContainerRegistry`
+## (deprecated) `conda_store_server.registry.ContainerRegistry`
 
 `ContainerRegistry.container_registries` (deprecated) dictionary of registries_url to upload built container images with callable function to configure registry instance with credentials.

--- a/docusaurus-docs/conda-store/references/configuration-options.md
+++ b/docusaurus-docs/conda-store/references/configuration-options.md
@@ -452,7 +452,7 @@ to. The default is all IP addresses `0.0.0.0`.
 `CondaStoreServer.port` is the port for conda-store server to
 use. Default is `8080`.
 
-`CondaStoreServer.registry_external_url` is the external hostname and
+`CondaStoreServer.registry_external_url` (deprecated) is the external hostname and
 port to access docker registry cannot contain `http://` or `https://`.
 
 `CondaStoreServer.url_prefix` is the prefix URL (subdirectory) for the

--- a/docusaurus-docs/conda-store/references/configuration-options.md
+++ b/docusaurus-docs/conda-store/references/configuration-options.md
@@ -307,8 +307,8 @@ bindings that an authenticated user assumes.
 `Authentication.cookie_name` is the name for the browser cookie used
 to authenticate users.
 
-`Authentication.cookie_domain` use when wanting to set a subdomain wide 
-cookie. For example setting this to `example.com` would allow the cookie 
+`Authentication.cookie_domain` use when wanting to set a subdomain wide
+cookie. For example setting this to `example.com` would allow the cookie
 to be valid for `example.com` along with `*.example.com`.
 
 `Authentication.authentication_backend` is the class to use for
@@ -486,10 +486,10 @@ is a regular python fastapi function.
 
 ### Deprecated configuration options for `conda_store_server._internal.server.app.CondaStoreServer`
 
-`CondaStoreServer.enable_registry` (deprecated) a Boolean on whether to 
+`CondaStoreServer.enable_registry` (deprecated) a Boolean on whether to
 expose the registry endpoints. Default False.
 
-`CondaStoreServer.registry_external_url` (deprecated) is the external hostname 
+`CondaStoreServer.registry_external_url` (deprecated) is the external hostname
 and port to access docker registry cannot contain `http://` or `https://`.
 
 ## `conda_store_server._internal.worker.app.CondaStoreWorker`

--- a/docusaurus-docs/conda-store/references/configuration-options.md
+++ b/docusaurus-docs/conda-store/references/configuration-options.md
@@ -441,8 +441,7 @@ endpoints. Default True.
 `CondaStoreServer.enable_api` a Boolean on whether to expose the API
 endpoints. Default True.
 
-`CondaStoreServer.enable_registry` a Boolean on whether to expose the
-registry endpoints. Default True.
+`CondaStoreServer.enable_registry` (deprecated) a Boolean on whether to expose the registry endpoints. Default False.
 
 `CondaStoreServer.enable_metrics` a Boolean on whether to expose the
 metrics endpoints. Default True.

--- a/examples/docker-without-nfs/assets/conda_store_config.py
+++ b/examples/docker-without-nfs/assets/conda_store_config.py
@@ -45,7 +45,6 @@ c.S3Storage.external_secure = True
 c.CondaStoreServer.log_level = logging.INFO
 c.CondaStoreServer.enable_ui = True
 c.CondaStoreServer.enable_api = True
-c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"
 c.CondaStoreServer.port = 8080

--- a/examples/docker/assets/conda_store_config.py
+++ b/examples/docker/assets/conda_store_config.py
@@ -40,7 +40,6 @@ c.S3Storage.external_secure = True
 c.CondaStoreServer.log_level = logging.INFO
 c.CondaStoreServer.enable_ui = True
 c.CondaStoreServer.enable_api = True
-c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"
 c.CondaStoreServer.port = 8080

--- a/examples/kubernetes/files/conda_store_config.py
+++ b/examples/kubernetes/files/conda_store_config.py
@@ -34,7 +34,6 @@ c.S3Storage.bucket_name = "conda-store"
 c.CondaStoreServer.log_level = logging.INFO
 c.CondaStoreServer.enable_ui = True
 c.CondaStoreServer.enable_api = True
-c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"
 c.CondaStoreServer.port = 8080

--- a/examples/ubuntu2004/templates/conda_store_config.py.j2
+++ b/examples/ubuntu2004/templates/conda_store_config.py.j2
@@ -30,7 +30,6 @@ c.S3Storage.external_secure = False
 c.CondaStoreServer.log_level = logging.INFO
 c.CondaStoreServer.enable_ui = True
 c.CondaStoreServer.enable_api = True
-c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"
 c.CondaStoreServer.port = 8080

--- a/tests/assets/conda_store_config.py
+++ b/tests/assets/conda_store_config.py
@@ -45,7 +45,6 @@ c.S3Storage.external_secure = False
 c.CondaStoreServer.log_level = logging.INFO
 c.CondaStoreServer.enable_ui = True
 c.CondaStoreServer.enable_api = True
-c.CondaStoreServer.enable_registry = True
 c.CondaStoreServer.reload = True
 c.CondaStoreServer.enable_metrics = True
 c.CondaStoreServer.address = "0.0.0.0"


### PR DESCRIPTION
fixes https://github.com/conda-incubator/conda-store/issues/942

## Description

This aims to start the process of removing the `/registry` endpoint. It:
* disables the registry endpoint by default
* adds deprecation headers to all the endpoints under `/registry`
* target deprecation date March 17, 2025


## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
