### PR TITLE
Separate conda-store app instance from config

### DIFF
--- a/conda-store-server/conda_store_server/_internal/orm.py
+++ b/conda-store-server/conda_store_server/_internal/orm.py
@@ -304,10 +304,10 @@ class Build(Base):
         else:
             namespace = ""
 
-        store_directory = os.path.abspath(conda_store.store_directory)
+        store_directory = os.path.abspath(conda_store.config.store_directory)
         res = (
             pathlib.Path(
-                conda_store.build_directory.format(
+                conda_store.config.build_directory.format(
                     store_directory=store_directory,
                     namespace=namespace,
                 )
@@ -320,7 +320,7 @@ class Build(Base):
             raise BuildPathError("build_path too long: must be <= 255 characters")
         # Note: cannot use the '/' operator to prepend the extended-length
         # prefix
-        if sys.platform == "win32" and conda_store.win_extended_length_prefix:
+        if sys.platform == "win32" and conda_store.config.win_extended_length_prefix:
             return pathlib.Path(f"\\\\?\\{res}")
         else:
             return res
@@ -342,17 +342,17 @@ class Build(Base):
         if BuildKey.current_version() >= 3:
             return None
 
-        store_directory = os.path.abspath(conda_store.store_directory)
+        store_directory = os.path.abspath(conda_store.config.store_directory)
         namespace = self.environment.namespace.name
         name = self.specification.name
         res = pathlib.Path(
-            conda_store.environment_directory.format(
+            conda_store.config.environment_directory.format(
                 store_directory=store_directory, namespace=namespace, name=name
             )
         )
         # Note: cannot use the '/' operator to prepend the extended-length
         # prefix
-        if sys.platform == "win32" and conda_store.win_extended_length_prefix:
+        if sys.platform == "win32" and conda_store.config.win_extended_length_prefix:
             return pathlib.Path(f"\\\\?\\{res}")
         else:
             return res

--- a/conda-store-server/conda_store_server/_internal/plugins/lock/conda_lock/conda_lock.py
+++ b/conda-store-server/conda_store_server/_internal/plugins/lock/conda_lock/conda_lock.py
@@ -23,7 +23,7 @@ class CondaLock(lock.LockPlugin):
         return settings.conda_command
 
     def _conda_flags(self, conda_store) -> str:
-        return conda_store.conda_flags
+        return conda_store.config.conda_flags
 
     @utils.run_in_tempdir
     def lock_environment(

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -199,17 +199,17 @@ class CondaStoreServer(Application):
 
         self.conda_store.ensure_directories()
         self.log.info(
-            f"Running conda-store with store directory: {self.conda_store.store_directory}"
+            f"Running conda-store with store directory: {self.conda_store.config.store_directory}"
         )
 
         self.authentication = self.authentication_class(
-            parent=self,
+            parent=self.conda_store_config,
             log=self.log,
             authentication_db=self.conda_store.session_factory,
         )
 
         # ensure checks on redis_url
-        self.conda_store.redis_url
+        self.conda_store.config.redis_url
 
     def init_fastapi_app(self):
         def trim_slash(url):
@@ -365,7 +365,7 @@ class CondaStoreServer(Application):
         # Creates a new DB connection since this will be run in a separate
         # thread and connections cannot be shared between threads
         session_factory = orm.new_session_factory(
-            url=self.conda_store.database_url,
+            url=self.conda_store.config.database_url,
             poolclass=QueuePool,
         )
 
@@ -390,8 +390,8 @@ class CondaStoreServer(Application):
 
     def start(self):
         """Start the CondaStoreServer application, and run a FastAPI-based webserver."""
-        if self.conda_store.upgrade_db:
-            dbutil.upgrade(self.conda_store.database_url)
+        if self.conda_store.config.upgrade_db:
+            dbutil.upgrade(self.conda_store.config.database_url)
 
         with self.conda_store.session_factory() as db:
             self.conda_store.ensure_settings(db)

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -35,8 +35,9 @@ import conda_store_server
 from conda_store_server import __version__, storage
 from conda_store_server._internal import dbutil, orm
 from conda_store_server._internal.server import views
-from conda_store_server.app import CondaStore
 from conda_store_server.server import auth
+from conda_store_server.conda_store import CondaStore 
+from conda_store_server.conda_store_config import CondaStore as CondaStoreConfig
 
 
 class _Color(str, Enum):
@@ -193,7 +194,8 @@ class CondaStoreServer(Application):
         super().initialize(*args, **kwargs)
         self.load_config_file(self.config_file)
 
-        self.conda_store = CondaStore(parent=self, log=self.log)
+        self.conda_store_config = CondaStoreConfig(parent=self, log=self.log)
+        self.conda_store = CondaStore(config=self.conda_store_config)
 
         self.conda_store.ensure_directories()
         self.log.info(

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -35,9 +35,9 @@ import conda_store_server
 from conda_store_server import __version__, storage
 from conda_store_server._internal import dbutil, orm
 from conda_store_server._internal.server import views
-from conda_store_server.server import auth
-from conda_store_server.conda_store import CondaStore 
+from conda_store_server.conda_store import CondaStore
 from conda_store_server.conda_store_config import CondaStore as CondaStoreConfig
+from conda_store_server.server import auth
 
 
 class _Color(str, Enum):

--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -12,12 +12,11 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, RedirectResponse
 
 from conda_store_server import __version__, api
-from conda_store_server.conda_store import CondaStore 
-from conda_store_server.conda_store_config import CondaStore as CondaStoreConfig
-from conda_store_server._internal import orm, schema, utils
+from conda_store_server._internal import orm, schema
 from conda_store_server._internal.environment import filter_environments
 from conda_store_server._internal.schema import AuthenticationToken, Permissions
 from conda_store_server._internal.server import dependencies
+from conda_store_server.conda_store import CondaStore
 from conda_store_server.exception import CondaStoreError
 from conda_store_server.server.auth import Authentication
 

--- a/conda-store-server/conda_store_server/_internal/server/views/ui.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/ui.py
@@ -32,7 +32,7 @@ async def ui_create_get_environment(
         )
 
         default_namespace = (
-            entity.primary_namespace if entity else conda_store.default_namespace
+            entity.primary_namespace if entity else conda_store.config.default_namespace
         )
 
         def sort_namespace(n):

--- a/conda-store-server/conda_store_server/_internal/worker/app.py
+++ b/conda-store-server/conda_store_server/_internal/worker/app.py
@@ -71,7 +71,7 @@ class CondaStoreWorker(Application):
         self.conda_store_config = CondaStoreConfig(parent=self, log=self.log)
         self.conda_store = CondaStore(config=self.conda_store_config)
         # ensure checks on redis_url
-        self.conda_store.redis_url
+        self.conda_store.config.redis_url
 
     def logger_to_celery_logging_level(self, logging_level):
         # celery supports the log levels DEBUG | INFO | WARNING | ERROR | CRITICAL | FATAL

--- a/conda-store-server/conda_store_server/_internal/worker/app.py
+++ b/conda-store-server/conda_store_server/_internal/worker/app.py
@@ -10,7 +10,7 @@ from traitlets import Integer, List, Unicode, validate
 from traitlets.config import Application, catch_config_error
 
 from conda_store_server import __version__
-from conda_store_server.conda_store import CondaStore 
+from conda_store_server.conda_store import CondaStore
 from conda_store_server.conda_store_config import CondaStore as CondaStoreConfig
 
 
@@ -67,7 +67,7 @@ class CondaStoreWorker(Application):
     def initialize(self, *args, **kwargs):
         super().initialize(*args, **kwargs)
         self.load_config_file(self.config_file)
-        
+
         self.conda_store_config = CondaStoreConfig(parent=self, log=self.log)
         self.conda_store = CondaStore(config=self.conda_store_config)
         # ensure checks on redis_url

--- a/conda-store-server/conda_store_server/_internal/worker/app.py
+++ b/conda-store-server/conda_store_server/_internal/worker/app.py
@@ -10,7 +10,8 @@ from traitlets import Integer, List, Unicode, validate
 from traitlets.config import Application, catch_config_error
 
 from conda_store_server import __version__
-from conda_store_server.app import CondaStore
+from conda_store_server.conda_store import CondaStore 
+from conda_store_server.conda_store_config import CondaStore as CondaStoreConfig
 
 
 class CondaStoreWorker(Application):
@@ -66,9 +67,9 @@ class CondaStoreWorker(Application):
     def initialize(self, *args, **kwargs):
         super().initialize(*args, **kwargs)
         self.load_config_file(self.config_file)
-
-        self.conda_store = CondaStore(parent=self, log=self.log)
-
+        
+        self.conda_store_config = CondaStoreConfig(parent=self, log=self.log)
+        self.conda_store = CondaStore(config=self.conda_store_config)
         # ensure checks on redis_url
         self.conda_store.redis_url
 

--- a/conda-store-server/conda_store_server/_internal/worker/tasks.py
+++ b/conda-store-server/conda_store_server/_internal/worker/tasks.py
@@ -87,7 +87,7 @@ def task_watch_paths(self):
         settings = conda_store.get_settings(db)
 
         conda_store.configuration(db).update_storage_metrics(
-            db, conda_store.store_directory
+            db, conda_store.config.store_directory
         )
 
         environment_paths = environment.discover_environments(self.worker.watch_paths)
@@ -106,7 +106,7 @@ def task_update_storage_metrics(self):
     conda_store = self.worker.conda_store
     with conda_store.session_factory() as db:
         conda_store.configuration(db).update_storage_metrics(
-            db, conda_store.store_directory
+            db, conda_store.config.store_directory
         )
 
 
@@ -174,7 +174,7 @@ def task_update_conda_channel(self, channel_name):
 
         is_locked = False
 
-        if conda_store.redis_url is not None:
+        if conda_store.config.redis_url is not None:
             lock = conda_store.redis.lock(task_key, timeout=60 * 15)  # timeout 15min
         else:
             lockfile_path = os.path.join(f"/tmp/task_lock_{task_key}")
@@ -195,7 +195,7 @@ def task_update_conda_channel(self, channel_name):
                 )
 
         except TimeoutError:
-            if conda_store.redis_url is None:
+            if conda_store.config.redis_url is None:
                 conda_store.log.warning(
                     f"Timeout when acquiring lock with key {task_key} - We assume the task is already being run"
                 )
@@ -269,7 +269,7 @@ def delete_build_artifact(db: Session, conda_store, build_artifact):
         # ignore key
         conda_prefix = build_artifact.build.build_path(conda_store)
         # be REALLY sure this is a directory within store directory
-        if str(conda_prefix).startswith(conda_store.store_directory) and os.path.isdir(
+        if str(conda_prefix).startswith(conda_store.config.store_directory) and os.path.isdir(
             conda_prefix
         ):
             shutil.rmtree(conda_prefix)

--- a/conda-store-server/conda_store_server/_internal/worker/tasks.py
+++ b/conda-store-server/conda_store_server/_internal/worker/tasks.py
@@ -269,9 +269,9 @@ def delete_build_artifact(db: Session, conda_store, build_artifact):
         # ignore key
         conda_prefix = build_artifact.build.build_path(conda_store)
         # be REALLY sure this is a directory within store directory
-        if str(conda_prefix).startswith(conda_store.config.store_directory) and os.path.isdir(
-            conda_prefix
-        ):
+        if str(conda_prefix).startswith(
+            conda_store.config.store_directory
+        ) and os.path.isdir(conda_prefix):
             shutil.rmtree(conda_prefix)
             db.delete(build_artifact)
     else:

--- a/conda-store-server/conda_store_server/conda_store.py
+++ b/conda-store-server/conda_store_server/conda_store.py
@@ -3,26 +3,26 @@
 # license that can be found in the LICENSE file.
 
 import datetime
+import logging
 import os
 from contextlib import contextmanager
 from typing import Any, Dict
-import logging
 
 import pydantic
 from celery import Celery, group
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
-from conda_store_server import CONDA_STORE_DIR, api, storage, conda_store_config
-from conda_store_server._internal import conda_utils, orm, schema, utils, environment
-from conda_store_server.plugins import hookspec, plugin_manager
+from conda_store_server import CONDA_STORE_DIR, api, conda_store_config, storage
+from conda_store_server._internal import conda_utils, orm, schema, utils
 from conda_store_server.exception import CondaStoreError
+from conda_store_server.plugins import hookspec, plugin_manager
 from conda_store_server.plugins.types import lock
 
 
 class CondaStore:
     """This class provides a set of common functionality to be used by
-    conda store servers and workers. 
+    conda store servers and workers.
 
     Attributes
     ----------
@@ -32,6 +32,7 @@ class CondaStore:
     log : logging.Logger
         global logger
     """
+
     def __init__(self, config: conda_store_config.CondaStore):
         self.config = config
         self.log = logging.getLogger(__name__)

--- a/conda-store-server/conda_store_server/conda_store.py
+++ b/conda-store-server/conda_store_server/conda_store.py
@@ -20,7 +20,18 @@ from conda_store_server.exception import CondaStoreError
 from conda_store_server.plugins.types import lock
 
 
-class CondaStore():
+class CondaStore:
+    """This class provides a set of common functionality to be used by
+    conda store servers and workers. 
+
+    Attributes
+    ----------
+    config : conda_store_config.CondaStore
+        CondaStore config object. This config object has global config
+        that is applied to both servers and workers.
+    log : logging.Logger
+        global logger
+    """
     def __init__(self, config: conda_store_config.CondaStore):
         self.config = config
         self.log = logging.getLogger(__name__)

--- a/conda-store-server/conda_store_server/conda_store.py
+++ b/conda-store-server/conda_store_server/conda_store.py
@@ -6,6 +6,7 @@ import datetime
 import os
 from contextlib import contextmanager
 from typing import Any, Dict
+import logging
 
 import pydantic
 from celery import Celery, group
@@ -22,6 +23,7 @@ from conda_store_server.plugins.types import lock
 class CondaStore():
     def __init__(self, config: conda_store_config.CondaStore):
         self.config = config
+        self.log = logging.getLogger(__name__)
 
     @property
     def session_factory(self) -> sessionmaker:
@@ -105,7 +107,7 @@ class CondaStore():
         #     return self._celery_app
 
         self._celery_app = Celery("tasks")
-        self._celery_app.config_from_object(self.config.celery_config)
+        self._celery_app.config_from_object(self.celery_config)
         return self._celery_app
 
     @property
@@ -145,7 +147,7 @@ class CondaStore():
             build_artifacts_kept_on_deletion=self.config.build_artifacts_kept_on_deletion,
             conda_solve_platforms=self.config.conda_solve_platforms,
             conda_channel_alias=self.config.conda_channel_alias,
-            conda_default_channels=self.confg.conda_default_channels,
+            conda_default_channels=self.config.conda_default_channels,
             conda_allowed_channels=self.config.conda_allowed_channels,
             conda_default_packages=self.config.conda_default_packages,
             conda_required_packages=self.config.conda_required_packages,
@@ -236,7 +238,7 @@ class CondaStore():
 
         return schema.Settings(**settings)
     
-    def conda_store_validate_specification(
+    def validate_specification(
         self,
         db: Session,
         namespace: str,
@@ -256,7 +258,7 @@ class CondaStore():
 
         return specification
 
-    def conda_store_validate_action(
+    def validate_action(
         self,
         db: Session,
         namespace: str,

--- a/conda-store-server/conda_store_server/conda_store_config.py
+++ b/conda-store-server/conda_store_server/conda_store_config.py
@@ -19,7 +19,7 @@ from traitlets import (
 )
 from traitlets.config import LoggingConfigurable
 
-from conda_store_server import CONDA_STORE_DIR, BuildKey, api, registry, storage
+from conda_store_server import CONDA_STORE_DIR, BuildKey, api, storage
 from conda_store_server._internal import conda_utils, environment, schema, utils
 
 
@@ -124,7 +124,6 @@ class CondaStore(LoggingConfigurable):
         if self.redis_url is not None:
             return self.redis_url
         return f"db+{self.database_url}"
-
 
     container_registry_class = Type(allow_none=True, help="(deprecated)")
 
@@ -291,6 +290,7 @@ class CondaStore(LoggingConfigurable):
         try:
             if self.redis_url is not None:
                 import redis
+
                 r = redis.Redis.from_url(self.redis_url)
                 r.ping()
         except Exception:

--- a/conda-store-server/conda_store_server/conda_store_config.py
+++ b/conda-store-server/conda_store_server/conda_store_config.py
@@ -202,7 +202,9 @@ class CondaStore(LoggingConfigurable):
     def _check_redis(self, proposal):
         try:
             if self.redis_url is not None:
-                self.redis.ping()
+                import redis
+                r = redis.Redis.from_url(self.redis_url)
+                r.ping()
         except Exception:
             raise TraitError(
                 f'c.CondaStore.redis_url unable to connect with Redis database at "{self.redis_url}"'

--- a/conda-store-server/conda_store_server/conda_store_config.py
+++ b/conda-store-server/conda_store_server/conda_store_config.py
@@ -1,0 +1,297 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+import os
+import sys
+
+from sqlalchemy.orm import Session
+from traitlets import (
+    Bool,
+    Callable,
+    Integer,
+    List,
+    TraitError,
+    Type,
+    Unicode,
+    default,
+    validate,
+)
+from traitlets.config import LoggingConfigurable
+
+from conda_store_server import CONDA_STORE_DIR, BuildKey, api, registry, storage
+from conda_store_server._internal import conda_utils, environment, schema, utils
+
+
+class CondaStore(LoggingConfigurable):
+    storage_class = Type(
+        default_value=storage.LocalStorage,
+        klass=storage.Storage,
+        allow_none=False,
+        config=True,
+    )
+
+    container_registry_class = Type(allow_none=True, help="(deprecated)")
+
+    store_directory = Unicode(
+        str(CONDA_STORE_DIR / "state"),
+        help="directory for conda-store to build environments and store state",
+        config=True,
+    )
+
+    build_directory = Unicode(
+        "{store_directory}/{namespace}",
+        help="Template used to form the directory for storing conda environment builds. Available keys: store_directory, namespace, name. The default will put all built environments in the same namespace within the same directory.",
+        config=True,
+    )
+
+    environment_directory = Unicode(
+        "{store_directory}/{namespace}/envs/{name}",
+        help="Template used to form the directory for symlinking conda environment builds. Available keys: store_directory, namespace, name. The default will put all environments in the same namespace within the same directory.",
+        config=True,
+    )
+
+    build_key_version = Integer(
+        BuildKey.set_current_version(2),
+        help="Build key version to use: 1 (long, legacy), 2 (shorter hash, default), 3 (hash-only, experimental)",
+        config=True,
+    )
+
+    @validate("build_key_version")
+    def _check_build_key_version(self, proposal):
+        try:
+            return BuildKey.set_current_version(proposal.value)
+        except Exception as e:
+            raise TraitError(f"c.CondaStore.build_key_version: {e}")
+
+    win_extended_length_prefix = Bool(
+        False,
+        help="Use the extended-length prefix '\\\\?\\' (Windows-only), default: False",
+        config=True,
+    )
+
+    conda_command = Unicode(
+        "mamba",
+        help="conda executable to use for solves",
+        config=True,
+    )
+
+    conda_solve_platforms = List(
+        [conda_utils.conda_platform()],
+        help="Conda platforms to solve environments for via conda-lock. Must include current platform.",
+        config=True,
+    )
+
+    conda_channel_alias = Unicode(
+        "https://conda.anaconda.org",
+        help="The prepended url location to associate with channel names",
+        config=True,
+    )
+
+    conda_flags = Unicode(
+        "--strict-channel-priority",
+        help="The flags to be passed through the CONDA_FLAGS environment variable during the environment build",
+        config=True,
+    )
+
+    conda_platforms = List(
+        [conda_utils.conda_platform(), "noarch"],
+        help="Conda platforms to download package repodata.json from. By default includes current architecture and noarch",
+        config=True,
+    )
+
+    conda_default_channels = List(
+        ["conda-forge"],
+        help="Conda channels that by default are included if channels are empty",
+        config=True,
+    )
+
+    conda_allowed_channels = List(
+        [],
+        help=(
+            "Allowed conda channels to be used in conda environments. "
+            "If set to empty list all channels are accepted (default). "
+            "Example: "
+            '["main", "conda-forge", "https://repo.anaconda.com/pkgs/main"]'
+        ),
+        config=True,
+    )
+
+    conda_indexed_channels = List(
+        ["main", "conda-forge", "https://repo.anaconda.com/pkgs/main"],
+        help="Conda channels to be indexed by conda-store at start.  Defaults to main and conda-forge.",
+        config=True,
+    )
+
+    conda_default_packages = List(
+        [],
+        help="Conda packages that included by default if none are included",
+        config=True,
+    )
+
+    conda_required_packages = List(
+        [],
+        help="Conda packages that are required to be within environment specification. Will raise a validation error is package not in specification",
+        config=True,
+    )
+
+    conda_included_packages = List(
+        [],
+        help="Conda packages that auto included within environment specification. Will not raise a validation error if package not in specification and will be auto added",
+        config=True,
+    )
+
+    lock_backend = Unicode(
+        default_value="conda-lock",
+        allow_none=False,
+        config=True,
+    )
+
+    pypi_default_packages = List(
+        [],
+        help="PyPi packages that included by default if none are included",
+        config=True,
+    )
+
+    pypi_required_packages = List(
+        [],
+        help="PyPi packages that are required to be within environment specification. Will raise a validation error is package not in specification",
+        config=True,
+    )
+
+    pypi_included_packages = List(
+        [],
+        help="PyPi packages that auto included within environment specification. Will not raise a validation error if package not in specification and will be auto added",
+        config=True,
+    )
+
+    conda_max_solve_time = Integer(
+        5 * 60,  # 5 minute
+        help="Maximum time in seconds to allow for solving a given conda environment",
+        config=True,
+    )
+
+    storage_threshold = Integer(
+        5 * 1024**3,  # 5 GB
+        help="Storage threshold in bytes of minimum available storage required in order to perform builds",
+        config=True,
+    )
+
+    database_url = Unicode(
+        "sqlite:///" + str(CONDA_STORE_DIR / "conda-store.sqlite"),
+        help="url for the database. e.g. 'sqlite:///conda-store.sqlite' tables will be automatically created if they do not exist",
+        config=True,
+    )
+
+    upgrade_db = Bool(
+        True,
+        help="""Upgrade the database automatically on start.
+        Only safe if database is regularly backed up.
+        """,
+        config=True,
+    )
+
+    redis_url = Unicode(
+        None,
+        help="Redis connection url in form 'redis://:<password>@<hostname>:<port>/0'. Connection is used by Celery along with conda-store internally",
+        config=True,
+        allow_none=True,
+    )
+
+    @validate("redis_url")
+    def _check_redis(self, proposal):
+        try:
+            if self.redis_url is not None:
+                self.redis.ping()
+        except Exception:
+            raise TraitError(
+                f'c.CondaStore.redis_url unable to connect with Redis database at "{self.redis_url}"'
+            )
+        return proposal.value
+
+    celery_broker_url = Unicode(
+        help="broker url to use for celery tasks",
+        config=True,
+    )
+
+    build_artifacts = List(
+        [
+            schema.BuildArtifactType.LOCKFILE,
+            schema.BuildArtifactType.YAML,
+            schema.BuildArtifactType.CONDA_PACK,
+            schema.BuildArtifactType.CONSTRUCTOR_INSTALLER,
+        ],
+        help="artifacts to build in conda-store. By default all of the artifacts",
+        config=True,
+    )
+
+    build_artifacts_kept_on_deletion = List(
+        [
+            schema.BuildArtifactType.LOGS,
+            schema.BuildArtifactType.LOCKFILE,
+            schema.BuildArtifactType.YAML,
+        ],
+        help="artifacts to keep on build deletion",
+        config=True,
+    )
+
+    serialize_builds = Bool(
+        True,
+        help="DEPRICATED no longer has any effect",
+        config=True,
+    )
+
+    @default("celery_broker_url")
+    def _default_celery_broker_url(self):
+        if self.redis_url is not None:
+            return self.redis_url
+        return f"sqla+{self.database_url}"
+
+    celery_results_backend = Unicode(
+        help="backend to use for celery task results",
+        config=True,
+    )
+
+    @default("celery_results_backend")
+    def _default_celery_results_backend(self):
+        if self.redis_url is not None:
+            return self.redis_url
+        return f"db+{self.database_url}"
+
+    default_namespace = Unicode(
+        "default", help="default namespace for conda-store", config=True
+    )
+
+    filesystem_namespace = Unicode(
+        "filesystem",
+        help="namespace to use for environments picked up via `CondaStoreWorker.watch_paths` on the filesystem",
+        config=True,
+    )
+
+    default_uid = Integer(
+        None if sys.platform == "win32" else os.getuid(),
+        help="default uid to assign to built environments",
+        config=True,
+        allow_none=True,
+    )
+
+    default_gid = Integer(
+        None if sys.platform == "win32" else os.getgid(),
+        help="default gid to assign to built environments",
+        config=True,
+        allow_none=True,
+    )
+
+    default_permissions = Unicode(
+        None if sys.platform == "win32" else "775",
+        help="default file permissions to assign to built environments",
+        config=True,
+        allow_none=True,
+    )
+
+    post_update_environment_build_hook = Callable(
+        default_value=None,
+        help="callable function taking conda_store and `orm.Environment` object as input arguments. This function can be used to add custom behavior that will run after an environment's current build changes.",
+        config=True,
+        allow_none=True,
+    )

--- a/conda-store-server/conda_store_server/conda_store_config.py
+++ b/conda-store-server/conda_store_server/conda_store_config.py
@@ -91,9 +91,6 @@ class CondaStore(LoggingConfigurable):
             schema.BuildArtifactType.LOGS,
             schema.BuildArtifactType.LOCKFILE,
             schema.BuildArtifactType.YAML,
-            # no possible way to delete these artifacts
-            # in most container registries via api
-            schema.BuildArtifactType.CONTAINER_REGISTRY,
         ],
         help="artifacts to keep on build deletion",
         config=True,
@@ -129,12 +126,7 @@ class CondaStore(LoggingConfigurable):
         return f"db+{self.database_url}"
 
 
-    container_registry_class = Type(
-        default_value=registry.ContainerRegistry,
-        klass=registry.ContainerRegistry,
-        allow_none=False,
-        config=True,
-    )
+    container_registry_class = Type(allow_none=True, help="(deprecated)")
 
     conda_command = Unicode(
         "mamba",

--- a/conda-store-server/tests/_internal/action/test_actions.py
+++ b/conda-store-server/tests/_internal/action/test_actions.py
@@ -117,7 +117,7 @@ def test_generate_constructor_installer(
             "conda_store_server._internal.action.generate_constructor_installer.logged_command"
         ) as mock_command:
             generate_constructor_installer.action_generate_constructor_installer(
-                conda_command=conda_store.conda_command,
+                conda_command=conda_store.config.conda_command,
                 specification=specification,
                 installer_dir=installer_dir,
                 version="1",
@@ -162,7 +162,7 @@ def test_install_specification(tmp_path, conda_store, simple_specification):
     conda_prefix = tmp_path / "test"
 
     action.action_install_specification(
-        conda_command=conda_store.conda_command,
+        conda_command=conda_store.config.conda_command,
         specification=simple_specification,
         conda_prefix=conda_prefix,
     )
@@ -183,7 +183,7 @@ def test_install_lockfile(tmp_path, conda_store, simple_conda_lock):
 @pytest.mark.long_running_test
 def test_generate_conda_export(conda_store, conda_prefix):
     context = action.action_generate_conda_export(
-        conda_command=conda_store.conda_command, conda_prefix=conda_prefix
+        conda_command=conda_store.config.conda_command, conda_prefix=conda_prefix
     )
     # The env name won't be correct because conda only sets the env name when
     # an environment is in an envs dir. See the discussion on PR #549.
@@ -327,9 +327,9 @@ def test_api_get_build_lockfile(
                 r"expected: \(1, 2, 3\)"
             ),
         ):
-            conda_store.build_key_version = build_key_version
+            conda_store.config.build_key_version = build_key_version
         return  # invalid, nothing more to test
-    conda_store.build_key_version = build_key_version
+    conda_store.config.build_key_version = build_key_version
     assert BuildKey.current_version() == build_key_version
     assert BuildKey.versions() == (1, 2, 3)
 

--- a/conda-store-server/tests/_internal/plugins/lock/test_conda_lock.py
+++ b/conda-store-server/tests/_internal/plugins/lock/test_conda_lock.py
@@ -98,7 +98,7 @@ def test_solve_lockfile_invalid_conda_flags(conda_store, simple_specification):
     locker = conda_lock.CondaLock()
 
     # Set invalid conda flags
-    conda_store.conda_flags = "--this-is-invalid"
+    conda_store.config.conda_flags = "--this-is-invalid"
 
     with pytest.raises(
         CalledProcessError,

--- a/conda-store-server/tests/_internal/worker/test_app.py
+++ b/conda-store-server/tests/_internal/worker/test_app.py
@@ -20,7 +20,7 @@ class MockCeleryApp:
 @pytest.mark.skipif(
     sys.platform == "win32", reason="celery beat is not supported on windows"
 )
-@patch("conda_store_server.app.CondaStore.celery_app")
+@patch("conda_store_server.conda_store.CondaStore.celery_app")
 def test_start_worker(mock_celery_app, conda_store_config):
     """Test that the celery worker is started with the right arguments"""
     mock_celery_app.return_value = MockCeleryApp()

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -14,7 +14,9 @@ import yaml
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from conda_store_server import api, app, storage
+from conda_store_server import api, storage
+from conda_store_server.conda_store import CondaStore 
+from conda_store_server.conda_store_config import CondaStore as CondaStoreConfig
 
 from conda_store_server._internal import (  # isort:skip
     action,
@@ -167,7 +169,8 @@ def seed_conda_store(db, conda_store):
 
 @pytest.fixture
 def conda_store(conda_store_config):
-    _conda_store = app.CondaStore(config=conda_store_config)
+    _conda_store_config = CondaStoreConfig(config=conda_store_config)
+    _conda_store = CondaStore(config=_conda_store_config)
 
     pathlib.Path(_conda_store.config.store_directory).mkdir(exist_ok=True)
 

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -35,8 +35,8 @@ def celery_config(tmp_path, conda_store):
     config = conda_store.celery_config
     config["traitlets"] = {
         "CondaStore": {
-            "database_url": conda_store.database_url,
-            "store_directory": conda_store.store_directory,
+            "database_url": conda_store.config.database_url,
+            "store_directory": conda_store.config.store_directory,
         }
     }
     config["beat_schedule_filename"] = str(
@@ -85,14 +85,14 @@ def conda_store_server(conda_store_config):
 
     _conda_store = _conda_store_server.conda_store
 
-    pathlib.Path(_conda_store.store_directory).mkdir(exist_ok=True)
+    pathlib.Path(_conda_store.config.store_directory).mkdir(exist_ok=True)
 
-    dbutil.upgrade(_conda_store.database_url)
+    dbutil.upgrade(_conda_store.config.database_url)
 
     with _conda_store.session_factory() as db:
         _conda_store.ensure_settings(db)
         _conda_store.configuration(db).update_storage_metrics(
-            db, _conda_store.store_directory
+            db, _conda_store.config.store_directory
         )
 
         _conda_store.celery_app
@@ -169,14 +169,14 @@ def seed_conda_store(db, conda_store):
 def conda_store(conda_store_config):
     _conda_store = app.CondaStore(config=conda_store_config)
 
-    pathlib.Path(_conda_store.store_directory).mkdir(exist_ok=True)
+    pathlib.Path(_conda_store.config.store_directory).mkdir(exist_ok=True)
 
-    dbutil.upgrade(_conda_store.database_url)
+    dbutil.upgrade(_conda_store.config.database_url)
 
     with _conda_store.session_factory() as db:
         _conda_store.ensure_settings(db)
         _conda_store.configuration(db).update_storage_metrics(
-            db, _conda_store.store_directory
+            db, _conda_store.config.store_directory
         )
 
         _conda_store.celery_app
@@ -276,7 +276,7 @@ def conda_prefix(conda_store, tmp_path, request):
     specification = schema.CondaSpecification(**request.param)
 
     action.action_install_specification(
-        conda_command=conda_store.conda_command,
+        conda_command=conda_store.config.conda_command,
         specification=specification,
         conda_prefix=conda_prefix,
     )
@@ -319,7 +319,7 @@ def _seed_conda_store(
 
 def _create_build_packages(db: Session, conda_store, build: orm.Build):
     channel_name = conda_utils.normalize_channel_name(
-        conda_store.conda_channel_alias, "conda-forge"
+        conda_store.config.conda_channel_alias, "conda-forge"
     )
     channel = api.ensure_conda_channel(db, channel_name)
 

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -15,7 +15,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from conda_store_server import api, storage
-from conda_store_server.conda_store import CondaStore 
+from conda_store_server.conda_store import CondaStore
 from conda_store_server.conda_store_config import CondaStore as CondaStoreConfig
 
 from conda_store_server._internal import (  # isort:skip

--- a/conda-store-server/tests/test_api.py
+++ b/conda-store-server/tests/test_api.py
@@ -329,17 +329,6 @@ def test_environment_crud(db):
     )
     assert environment is not None
 
-    # # check that deleting a environment works
-    # api.delete_environment(conda_store.db, namespace_id=namespace.id, name=environment_name)
-    # conda_store.db.commit()
-
-    # assert len(api.list_environment(conda_store.db).all()) == 0
-
-    # # check that ensuring a environment doesn't creates one
-    # api.ensure_environment(conda_store.db, name=environment_name, namespace_id=namespace.id)
-
-    # assert len(api.list_environments(conda_store.db).all()) == 1
-
 
 def test_get_set_keyvaluestore(db):
     setting_1 = {"a": 1, "b": 2}
@@ -364,7 +353,7 @@ def test_get_set_keyvaluestore(db):
 
 
 def test_build_path_too_long(db, conda_store, simple_specification):
-    conda_store.store_directory = "A" * 800
+    conda_store.config.store_directory = "A" * 800
     build_id = conda_store.register_environment(
         db, specification=simple_specification, namespace="pytest"
     )

--- a/conda-store-server/tests/test_conda_store.py
+++ b/conda-store-server/tests/test_conda_store.py
@@ -178,7 +178,7 @@ def test_conda_store_register_environment_duplicate_force_true(db, conda_store):
 
 def test_conda_store_get_lock_plugin(conda_store):
     lock_plugin_setting = "conda-lock"
-    conda_store.lock_backend = lock_plugin_setting
+    conda_store.config.lock_backend = lock_plugin_setting
     name, plugin = conda_store.lock_plugin()
     assert name == lock_plugin_setting
     assert isinstance(plugin, conda_lock.CondaLock)
@@ -186,6 +186,6 @@ def test_conda_store_get_lock_plugin(conda_store):
 
 def test_conda_store_get_lock_plugin_does_not_exist(conda_store):
     lock_plugin_setting = "idontexist"
-    conda_store.lock_backend = lock_plugin_setting
+    conda_store.config.lock_backend = lock_plugin_setting
     with pytest.raises(CondaStorePluginNotFoundError):
         conda_store.lock_plugin()

--- a/conda-store-server/tests/test_conda_store_config.py
+++ b/conda-store-server/tests/test_conda_store_config.py
@@ -147,8 +147,9 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
         },
     )
 
-    global_specification = conda_store.validate_specification(
+    global_specification = conda_store.config.validate_specification(
         db,
+        conda_store=conda_store,
         namespace="default",
         specification=schema.CondaSpecification(
             name="test",
@@ -178,8 +179,9 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
         },
     )
 
-    namespace_specification = conda_store.validate_specification(
+    namespace_specification = conda_store.config.validate_specification(
         db,
+        conda_store=conda_store,
         namespace="default",
         specification=schema.CondaSpecification(
             name="test",
@@ -211,8 +213,9 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
         },
     )
 
-    environment_specification = conda_store.validate_specification(
+    environment_specification = conda_store.config.validate_specification(
         db,
+        conda_store=conda_store,
         namespace="default",
         specification=schema.CondaSpecification(
             name="test",
@@ -233,8 +236,9 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
 
     # not allowed channel name
     with pytest.raises(ValueError):
-        conda_store.validate_specification(
+        conda_store.config.validate_specification(
             db,
+            conda_store=conda_store,
             namespace="default",
             specification=schema.CondaSpecification(
                 name="test",
@@ -245,8 +249,9 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
 
     # missing required conda package
     with pytest.raises(ValueError):
-        conda_store.validate_specification(
+        conda_store.config.validate_specification(
             db,
+            conda_store=conda_store,
             namespace="default",
             specification=schema.CondaSpecification(
                 name="test", channels=["conda-forge"], dependencies=[{"pip": ["numpy"]}]
@@ -255,8 +260,9 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
 
     # missing required pip package
     with pytest.raises(ValueError):
-        conda_store.validate_specification(
+        conda_store.config.validate_specification(
             db,
+            conda_store=conda_store,
             namespace="default",
             specification=schema.CondaSpecification(
                 name="test", channels=["conda-forge"], dependencies=["flask"]

--- a/conda-store-server/tests/test_conda_store_config.py
+++ b/conda-store-server/tests/test_conda_store_config.py
@@ -149,7 +149,6 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
 
     global_specification = conda_store.validate_specification(
         db,
-        conda_store,
         namespace="default",
         specification=schema.CondaSpecification(
             name="test",
@@ -181,7 +180,6 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
 
     namespace_specification = conda_store.validate_specification(
         db,
-        conda_store,
         namespace="default",
         specification=schema.CondaSpecification(
             name="test",
@@ -215,7 +213,6 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
 
     environment_specification = conda_store.validate_specification(
         db,
-        conda_store,
         namespace="default",
         specification=schema.CondaSpecification(
             name="test",
@@ -238,7 +235,6 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
     with pytest.raises(ValueError):
         conda_store.validate_specification(
             db,
-            conda_store,
             namespace="default",
             specification=schema.CondaSpecification(
                 name="test",
@@ -251,7 +247,6 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
     with pytest.raises(ValueError):
         conda_store.validate_specification(
             db,
-            conda_store,
             namespace="default",
             specification=schema.CondaSpecification(
                 name="test", channels=["conda-forge"], dependencies=[{"pip": ["numpy"]}]
@@ -262,7 +257,6 @@ def test_conda_store_settings_conda_channels_packages_validate_valid(db, conda_s
     with pytest.raises(ValueError):
         conda_store.validate_specification(
             db,
-            conda_store,
             namespace="default",
             specification=schema.CondaSpecification(
                 name="test", channels=["conda-forge"], dependencies=["flask"]


### PR DESCRIPTION
pre req for resolving https://github.com/conda-incubator/conda-store/issues/1005

## Description

This PR refactors `conda_store_server/app.py` to split the config portion and app instance portion of the class. The goal of this refactor is more clearly delineate responsibility between the 2 classes/pieces of functionality. Eventually, this should also make how to approach changes to the config more clear.

2 new objects are introduced:
* `conda_store_config:CondaStore`
  * this is the config class for conda store
  * it uses traitlets to get config
  * it's only responsibility is to read the config file and provide that info to `conda_store:CondaStore`
* `conda_store:CondaStore`
  *  this has common app functions like `get_settings`, `set_settings`, etc
  * it gets it's configuration from `conda_store_config:CondaStore`
  * it's responsibility is to have shared instance information and provide common functionality

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
