### PR TITLE
Don't output db secret to logs

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -197,9 +197,6 @@ class CondaStoreServer(Application):
 
         self.conda_store.ensure_directories()
         self.log.info(
-            f"Running conda-store with database: {self.conda_store.database_url}"
-        )
-        self.log.info(
             f"Running conda-store with store directory: {self.conda_store.store_directory}"
         )
 


### PR DESCRIPTION
## Description

The `database_url` also includes the username + password for accessing the db. Outputting this to the logs is not good.

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

