### PR TITLE
Remove exception handler that prints to the console

### DIFF
--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -256,7 +256,9 @@ class CondaStoreServer(Application):
             return response
 
         @app.exception_handler(HTTPException)
-        async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+        async def http_exception_handler(
+            request: Request, exc: HTTPException
+        ) -> JSONResponse:
             return JSONResponse(
                 {
                     "status": "error",

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -254,7 +254,7 @@ class CondaStoreServer(Application):
             return response
 
         @app.exception_handler(HTTPException)
-        async def http_exception_handler(request, exc):
+        async def http_exception_handler(request, exc: HTTPException):
             return JSONResponse(
                 {
                     "status": "error",
@@ -262,14 +262,6 @@ class CondaStoreServer(Application):
                 },
                 status_code=exc.status_code,
             )
-
-        # Prints exceptions to the terminal
-        # https://fastapi.tiangolo.com/tutorial/handling-errors/#re-use-fastapis-exception-handlers
-        # https://github.com/tiangolo/fastapi/issues/1241
-        @app.exception_handler(Exception)
-        async def exception_handler(request, exc):
-            print(exc)
-            return await http_exception_handler(request, exc)
 
         app.include_router(
             self.authentication.router,

--- a/conda-store-server/conda_store_server/_internal/server/app.py
+++ b/conda-store-server/conda_store_server/_internal/server/app.py
@@ -256,7 +256,7 @@ class CondaStoreServer(Application):
             return response
 
         @app.exception_handler(HTTPException)
-        async def http_exception_handler(request, exc: HTTPException):
+        async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
             return JSONResponse(
                 {
                     "status": "error",


### PR DESCRIPTION
## Description

Errors will already be printed to the console if the log level is set to `DEBUG`.

Having this exception handler catch all exceptions and invoke the http_exception_handler is incorrect behaviour. This causes the http_exception_handler to be called for non HTTPExceptions. Since the exception passed in is the wrong type, this often causes a new exception to be triggered.

For example, when handling a non HTTPException, this will be in the error message
```
conda-store-server-1  | Traceback (most recent call last):
conda-store-server-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
conda-store-server-1  |     result = await app(  # type: ignore[func-returns-value]
conda-store-server-1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
conda-store-server-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
conda-store-server-1  |     await super().__call__(scope, receive, send)
conda-store-server-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/starlette/applications.py", line 113, in __call__
conda-store-server-1  |     await self.middleware_stack(scope, receive, send)
conda-store-server-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/starlette/middleware/errors.py", line 177, in __call__
conda-store-server-1  |     response = await self.handler(request, exc)
conda-store-server-1  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
conda-store-server-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/conda_store_server/_internal/server/app.py", line 275, in exception_handler
conda-store-server-1  |     return await http_exception_handler(request, exc)
conda-store-server-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
conda-store-server-1  |   File "/opt/conda/envs/conda-store-server/lib/python3.12/site-packages/conda_store_server/_internal/server/app.py", line 264, in http_exception_handler
conda-store-server-1  |     "message": exc.detail,
conda-store-server-1  |                ^^^^^^^^^^
conda-store-server-1  | AttributeError: 'NoMatchFound' object has no attribute 'detail'
```

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

