### PR TITLE
Update test_disk_usage for change in default `du` behaviour in ubuntu 24.04

### DIFF
--- a/conda-store-server/tests/_internal/test_utils.py
+++ b/conda-store-server/tests/_internal/test_utils.py
@@ -12,8 +12,8 @@ def test_disk_usage(tmp_path):
     test_dir.mkdir()
 
     # This varies across OSes
-    dir_size = du(test_dir)
-    assert abs(dir_size - int(disk_usage(test_dir))) <= 1000
+    initial_du_size = du(test_dir)
+    initial_disk_usage_size = int(disk_usage(test_dir))
 
     test_file = test_dir / "test_file"
     test_file.write_text("a" * 1000)
@@ -33,5 +33,5 @@ def test_disk_usage(tmp_path):
 
     val = disk_usage(test_dir)
     assert isinstance(val, str)
-    assert 2000 + dir_size <= int(val) <= 2700 + dir_size
-    assert 2000 + dir_size <= du(test_dir) <= 2700 + dir_size
+    assert initial_disk_usage_size < int(val)
+    assert initial_du_size <= du(test_dir)


### PR DESCRIPTION
## Description

This test started failing due to a difference in how `du` works on ubuntu 24.04 (the new `ubuntu-latest` version in GHA) and ubuntu 22.04. See the following example:

```
(conda-store-server-dev) sophia:conda-store-server/ (test_disk_usage-test✗) $ docker run -i
t ubuntu:24.04
Unable to find image 'ubuntu:24.04' locally
24.04: Pulling from library/ubuntu
de44b265507a: Pull complete 
Digest: sha256:80dd3c3b9c6cecb9f1667e9290b3bc61b78c2678c02cbdae5f0fea92cc6734ab
Status: Downloaded newer image for ubuntu:24.04
root@55628d140146:/# mkdir /test
root@55628d140146:/# du -sb test/
0       test/
root@55628d140146:/# 
exit

(conda-store-server-dev) sophia:conda-store-server/ (test_disk_usage-test✗) $ docker run -it ubuntu:22.04
Unable to find image 'ubuntu:22.04' locally
22.04: Pulling from library/ubuntu
6414378b6477: Pull complete 
Digest: sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97
Status: Downloaded newer image for ubuntu:22.04
root@65ab5dc1cd16:/# mkdir /test
root@65ab5dc1cd16:/# du -sb test/
4096    test/
```

This change updates the test to focus on the change in test tmp dir size in order to make the test more applicable across supported OSes.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

