### PR TITLE
Get database url from conda-store config in tests

### DIFF
--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -298,7 +298,7 @@ def alembic_config(conda_store):
     from conda_store_server._internal.dbutil import write_alembic_ini
 
     ini_file = pathlib.Path(__file__).parent / "alembic.ini"
-    write_alembic_ini(ini_file, conda_store.database_url)
+    write_alembic_ini(ini_file, conda_store.config.database_url)
     return {"file": ini_file}
 
 


### PR DESCRIPTION
https://github.com/conda-incubator/conda-store/pull/1023 introduced splitting conda store config from the conda store class. This pr updates tests that got left out.