### PR TITLE
Move auth related schema to inside the auth module

### DIFF
--- a/conda-store-server/conda_store_server/_internal/environment.py
+++ b/conda-store-server/conda_store_server/_internal/environment.py
@@ -9,7 +9,6 @@ import yaml
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Query
 
-from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal import conda_utils, orm, schema, utils
 from conda_store_server.server import schema as auth_schema
 

--- a/conda-store-server/conda_store_server/_internal/environment.py
+++ b/conda-store-server/conda_store_server/_internal/environment.py
@@ -9,7 +9,9 @@ import yaml
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Query
 
+from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal import conda_utils, orm, schema, utils
+from conda_store_server.server import schema as auth_schema
 
 
 def validate_environment(specification):
@@ -151,7 +153,7 @@ def validate_environment_pypi_packages(
 
 def filter_environments(
     query: Query,
-    role_bindings: schema.RoleBindings,
+    role_bindings: auth_schema.RoleBindings,
 ) -> Query:
     """Filter a query containing environments and namespaces by a set of role bindings.
 
@@ -159,7 +161,7 @@ def filter_environments(
     ----------
     query : Query
         Query containing both environments and namespaces
-    role_bindings : schema.RoleBindings
+    role_bindings : auth_schema.RoleBindings
         Role bindings to filter the results by
 
     Returns
@@ -171,7 +173,7 @@ def filter_environments(
     cases = []
     for entity_arn, entity_roles in role_bindings.items():
         namespace, name = utils.compile_arn_sql_like(
-            entity_arn, schema.ARN_ALLOWED_REGEX
+            entity_arn, auth_schema.ARN_ALLOWED_REGEX
         )
         cases.append(
             and_(

--- a/conda-store-server/conda_store_server/_internal/orm.py
+++ b/conda-store-server/conda_store_server/_internal/orm.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import (
 )
 
 from conda_store_server._internal import conda_utils, schema, utils
+from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal.environment import validate_environment
 from conda_store_server.exception import BuildPathError
 
@@ -101,7 +102,7 @@ class NamespaceRoleMapping(Base):
 
     @validates("entity")
     def validate_entity(self, key, entity):
-        if not schema.ARN_ALLOWED_REGEX.match(entity):
+        if not auth_schema.ARN_ALLOWED_REGEX.match(entity):
             raise ValueError(f"invalid entity={entity}")
 
         return entity

--- a/conda-store-server/conda_store_server/_internal/orm.py
+++ b/conda-store-server/conda_store_server/_internal/orm.py
@@ -40,9 +40,9 @@ from sqlalchemy.orm import (
 )
 
 from conda_store_server._internal import conda_utils, schema, utils
-from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal.environment import validate_environment
 from conda_store_server.exception import BuildPathError
+from conda_store_server.server import schema as auth_schema
 
 logger = logging.getLogger("orm")
 

--- a/conda-store-server/conda_store_server/_internal/schema.py
+++ b/conda-store-server/conda_store_server/_internal/schema.py
@@ -4,11 +4,10 @@
 
 import datetime
 import enum
-import functools
 import os
 import re
 import sys
-from typing import Annotated, Any, Dict, List, Optional, TypeAlias, Union
+from typing import Annotated, Any, Dict, List, Optional, Union
 
 from conda_lock.lockfile.v1.models import Lockfile
 from pydantic import (
@@ -24,64 +23,12 @@ from conda_store_server._internal import conda_utils
 from conda_store_server.exception import CondaStoreError
 
 
-def _datetime_factory(offset: datetime.timedelta):
-    """Utcnow datetime + timezone as string"""
-    return datetime.datetime.utcnow() + offset
-
-
-# An ARN is a string which matches namespaces and environments. For example:
-#     */*          matches all environments
-#     */team       matches all environments named 'team' in any namespace
-#
-# Namespaces and environment names cannot contain "*" ":" "#" " " "/"
 ALLOWED_CHARACTERS = "A-Za-z0-9-+_@$&?^~.="
-ARN_ALLOWED = f"^([{ALLOWED_CHARACTERS}*]+)/([{ALLOWED_CHARACTERS}*]+)$"
-ARN_ALLOWED_REGEX = re.compile(ARN_ALLOWED)
-
-
-#########################
-# Authentication Schema
-#########################
-
-RoleBindings: TypeAlias = Dict[
-    Annotated[str, StringConstraints(pattern=ARN_ALLOWED)], List[str]
-]
-
-
-class Permissions(enum.Enum):
-    """Permissions map to conda-store actions"""
-
-    ENVIRONMENT_CREATE = "environment:create"
-    ENVIRONMENT_READ = "environment::read"
-    ENVIRONMENT_UPDATE = "environment::update"
-    ENVIRONMENT_DELETE = "environment::delete"
-    ENVIRONMENT_SOLVE = "environment::solve"
-    BUILD_CANCEL = "build::cancel"
-    BUILD_DELETE = "build::delete"
-    NAMESPACE_CREATE = "namespace::create"
-    NAMESPACE_READ = "namespace::read"
-    NAMESPACE_UPDATE = "namespace::update"
-    NAMESPACE_DELETE = "namespace::delete"
-    NAMESPACE_ROLE_MAPPING_CREATE = "namespace-role-mapping::create"
-    NAMESPACE_ROLE_MAPPING_READ = "namespace-role-mapping::read"
-    NAMESPACE_ROLE_MAPPING_UPDATE = "namespace-role-mapping::update"
-    NAMESPACE_ROLE_MAPPING_DELETE = "namespace-role-mapping::delete"
-    SETTING_READ = "setting::read"
-    SETTING_UPDATE = "setting::update"
-
-
-class AuthenticationToken(BaseModel):
-    exp: datetime.datetime = Field(
-        default_factory=functools.partial(_datetime_factory, datetime.timedelta(days=1))
-    )
-    primary_namespace: str = "default"
-    role_bindings: RoleBindings = {}
 
 
 ##########################
 # Database Schema
 ##########################
-
 
 class StorageBackend(enum.Enum):
     FILESYSTEM = "filesystem"

--- a/conda-store-server/conda_store_server/_internal/schema.py
+++ b/conda-store-server/conda_store_server/_internal/schema.py
@@ -22,13 +22,13 @@ from pydantic import (
 from conda_store_server._internal import conda_utils
 from conda_store_server.exception import CondaStoreError
 
-
 ALLOWED_CHARACTERS = "A-Za-z0-9-+_@$&?^~.="
 
 
 ##########################
 # Database Schema
 ##########################
+
 
 class StorageBackend(enum.Enum):
     FILESYSTEM = "filesystem"

--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -14,11 +14,12 @@ from fastapi.responses import JSONResponse, PlainTextResponse, RedirectResponse
 from conda_store_server import __version__, api
 from conda_store_server._internal import orm, schema
 from conda_store_server._internal.environment import filter_environments
-from conda_store_server._internal.schema import AuthenticationToken, Permissions
 from conda_store_server._internal.server import dependencies
 from conda_store_server.conda_store import CondaStore
 from conda_store_server.exception import CondaStoreError
 from conda_store_server.server.auth import Authentication
+from conda_store_server.server.schema import AuthenticationToken, Permissions
+from conda_store_server.server import schema as auth_schema
 
 
 class PaginatedArgs(TypedDict):
@@ -225,14 +226,14 @@ async def api_post_token(
     entity=Depends(dependencies.get_entity),
 ):
     if entity is None:
-        entity = schema.AuthenticationToken(
+        entity = auth_schema.AuthenticationToken(
             exp=datetime.datetime.now(tz=datetime.timezone.utc)
             + datetime.timedelta(days=1),
             primary_namespace=conda_store.config.default_namespace,
             role_bindings={},
         )
 
-    new_entity = schema.AuthenticationToken(
+    new_entity = auth_schema.AuthenticationToken(
         exp=expiration or entity.exp,
         primary_namespace=primary_namespace or entity.primary_namespace,
         role_bindings=role_bindings or auth.authorization.get_entity_bindings(entity),
@@ -672,7 +673,7 @@ async def api_list_environments(
         If specified, filter by environments containing the given package name(s)
     artifact : Optional[schema.BuildArtifactType]
         If specified, filter by environments with the given BuildArtifactType
-    jwt : Optional[schema.AuthenticationToken]
+    jwt : Optional[auth_schema.AuthenticationToken]
         If specified, retrieve only the environments accessible to this token; that is,
         only return environments that the user has 'admin', 'editor', and 'viewer'
         role bindings for.

--- a/conda-store-server/conda_store_server/_internal/server/views/api.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/api.py
@@ -17,9 +17,9 @@ from conda_store_server._internal.environment import filter_environments
 from conda_store_server._internal.server import dependencies
 from conda_store_server.conda_store import CondaStore
 from conda_store_server.exception import CondaStoreError
+from conda_store_server.server import schema as auth_schema
 from conda_store_server.server.auth import Authentication
 from conda_store_server.server.schema import AuthenticationToken, Permissions
-from conda_store_server.server import schema as auth_schema
 
 
 class PaginatedArgs(TypedDict):

--- a/conda-store-server/conda_store_server/_internal/server/views/registry.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/registry.py
@@ -13,7 +13,6 @@ from conda_store_server._internal import orm, schema
 from conda_store_server._internal.server import dependencies
 from conda_store_server.server.schema import Permissions
 
-
 router_registry = APIRouter(tags=["registry"])
 
 

--- a/conda-store-server/conda_store_server/_internal/server/views/registry.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/registry.py
@@ -10,8 +10,9 @@ from fastapi.responses import RedirectResponse, Response
 
 from conda_store_server import api
 from conda_store_server._internal import orm, schema
-from conda_store_server._internal.schema import Permissions
 from conda_store_server._internal.server import dependencies
+from conda_store_server.server.schema import Permissions
+
 
 router_registry = APIRouter(tags=["registry"])
 

--- a/conda-store-server/conda_store_server/_internal/server/views/ui.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/ui.py
@@ -12,7 +12,7 @@ from conda_store_server import api
 from conda_store_server._internal.action.generate_constructor_installer import (
     get_installer_platform,
 )
-from conda_store_server._internal.schema import Permissions
+from conda_store_server.server.schema import Permissions
 from conda_store_server._internal.server import dependencies
 
 router_ui = APIRouter(tags=["ui"])

--- a/conda-store-server/conda_store_server/_internal/server/views/ui.py
+++ b/conda-store-server/conda_store_server/_internal/server/views/ui.py
@@ -12,8 +12,8 @@ from conda_store_server import api
 from conda_store_server._internal.action.generate_constructor_installer import (
     get_installer_platform,
 )
-from conda_store_server.server.schema import Permissions
 from conda_store_server._internal.server import dependencies
+from conda_store_server.server.schema import Permissions
 
 router_ui = APIRouter(tags=["ui"])
 

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -9,9 +9,9 @@ from typing import Any, Dict, List, Union
 from sqlalchemy import distinct, func, null, or_
 from sqlalchemy.orm import Query, aliased, session
 
-from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal import conda_utils, orm, schema, utils
 from conda_store_server._internal.environment import filter_environments
+from conda_store_server.server import schema as auth_schema
 
 
 def list_namespaces(db, show_soft_deleted: bool = False):

--- a/conda-store-server/conda_store_server/api.py
+++ b/conda-store-server/conda_store_server/api.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Union
 from sqlalchemy import distinct, func, null, or_
 from sqlalchemy.orm import Query, aliased, session
 
+from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal import conda_utils, orm, schema, utils
 from conda_store_server._internal.environment import filter_environments
 
@@ -284,7 +285,7 @@ def list_environments(
     artifact: schema.BuildArtifactType = None,
     search: str = None,
     show_soft_deleted: bool = False,
-    role_bindings: schema.RoleBindings | None = None,
+    role_bindings: auth_schema.RoleBindings | None = None,
 ) -> Query:
     """Retrieve all environments managed by conda-store.
 
@@ -308,7 +309,7 @@ def list_environments(
     show_soft_deleted : bool
         If specified, filter by environments which have a null value for the
         deleted_on attribute
-    role_bindings : schema.RoleBindings | None
+    role_bindings : auth_schema.RoleBindings | None
         If specified, filter by only the environments the given role_bindings
         have read, write, or admin access to. This should be the same object as
         the role bindings in conda_store_config.py, for example:

--- a/conda-store-server/conda_store_server/conda_store.py
+++ b/conda-store-server/conda_store_server/conda_store.py
@@ -14,11 +14,11 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from conda_store_server import CONDA_STORE_DIR, api, conda_store_config, storage
-from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal import conda_utils, orm, schema, utils
 from conda_store_server.exception import CondaStoreError
 from conda_store_server.plugins import hookspec, plugin_manager
 from conda_store_server.plugins.types import lock
+from conda_store_server.server import schema as auth_schema
 
 
 class CondaStore:

--- a/conda-store-server/conda_store_server/conda_store.py
+++ b/conda-store-server/conda_store_server/conda_store.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from conda_store_server import CONDA_STORE_DIR, api, conda_store_config, storage
+from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal import conda_utils, orm, schema, utils
 from conda_store_server.exception import CondaStoreError
 from conda_store_server.plugins import hookspec, plugin_manager
@@ -258,7 +259,7 @@ class CondaStore:
             db=db,
             conda_store=self,
             namespace="solve",
-            action=schema.Permissions.ENVIRONMENT_SOLVE,
+            action=auth_schema.Permissions.ENVIRONMENT_SOLVE,
         )
 
         specification_model = self.config.validate_specification(
@@ -303,7 +304,7 @@ class CondaStore:
             db=db,
             conda_store=self,
             namespace=namespace.name,
-            action=schema.Permissions.ENVIRONMENT_CREATE,
+            action=auth_schema.Permissions.ENVIRONMENT_CREATE,
         )
 
         if is_lockfile:
@@ -359,7 +360,7 @@ class CondaStore:
             db=db,
             conda_store=self,
             namespace=environment.namespace.name,
-            action=schema.Permissions.ENVIRONMENT_UPDATE,
+            action=auth_schema.Permissions.ENVIRONMENT_UPDATE,
         )
 
         settings = self.get_settings(
@@ -426,7 +427,7 @@ class CondaStore:
             db=db,
             conda_store=self,
             namespace=namespace,
-            action=schema.Permissions.ENVIRONMENT_UPDATE,
+            action=auth_schema.Permissions.ENVIRONMENT_UPDATE,
         )
 
         build = api.get_build(db, build_id)
@@ -475,7 +476,7 @@ class CondaStore:
             db=db,
             conda_store=self,
             namespace=namespace,
-            action=schema.Permissions.NAMESPACE_DELETE,
+            action=auth_schema.Permissions.NAMESPACE_DELETE,
         )
 
         namespace = api.get_namespace(db, name=namespace)
@@ -502,7 +503,7 @@ class CondaStore:
             db=db,
             conda_store=self,
             namespace=namespace,
-            action=schema.Permissions.ENVIRONMENT_DELETE,
+            action=auth_schema.Permissions.ENVIRONMENT_DELETE,
         )
 
         environment = api.get_environment(db, namespace=namespace, name=name)
@@ -531,7 +532,7 @@ class CondaStore:
             db=db,
             conda_store=self,
             namespace=build.environment.namespace.name,
-            action=schema.Permissions.BUILD_DELETE,
+            action=auth_schema.Permissions.BUILD_DELETE,
         )
 
         if build.status not in [

--- a/conda-store-server/conda_store_server/conda_store_config.py
+++ b/conda-store-server/conda_store_server/conda_store_config.py
@@ -20,6 +20,7 @@ from traitlets import (
 from traitlets.config import LoggingConfigurable
 
 from conda_store_server import CONDA_STORE_DIR, BuildKey, api, storage
+from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal import conda_utils, environment, schema, utils
 
 
@@ -48,14 +49,14 @@ def conda_store_validate_action(
     db: Session,
     conda_store,
     namespace: str,
-    action: schema.Permissions,
+    action: auth_schema.Permissions,
 ) -> None:
     settings = conda_store.get_settings(db)
     system_metrics = api.get_system_metrics(db)
 
     if action in (
-        schema.Permissions.ENVIRONMENT_CREATE,
-        schema.Permissions.ENVIRONMENT_UPDATE,
+        auth_schema.Permissions.ENVIRONMENT_CREATE,
+        auth_schema.Permissions.ENVIRONMENT_UPDATE,
     ) and (settings.storage_threshold > system_metrics.disk_free):
         raise utils.CondaStoreError(
             f"`CondaStore.storage_threshold` reached. Action {action.value} prevented due to insufficient storage space"

--- a/conda-store-server/conda_store_server/conda_store_config.py
+++ b/conda-store-server/conda_store_server/conda_store_config.py
@@ -20,8 +20,8 @@ from traitlets import (
 from traitlets.config import LoggingConfigurable
 
 from conda_store_server import CONDA_STORE_DIR, BuildKey, api, storage
-from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal import conda_utils, environment, schema, utils
+from conda_store_server.server import schema as auth_schema
 
 
 def conda_store_validate_specification(

--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -33,9 +33,9 @@ from traitlets import (
 from traitlets.config import LoggingConfigurable
 
 from conda_store_server import api
-from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal import environment, orm, schema, utils
 from conda_store_server._internal.server import dependencies
+from conda_store_server.server import schema as auth_schema
 
 
 class AuthenticationBackend(LoggingConfigurable):

--- a/conda-store-server/conda_store_server/server/schema.py
+++ b/conda-store-server/conda_store_server/server/schema.py
@@ -3,8 +3,8 @@
 # license that can be found in the LICENSE file.
 
 import datetime
-import functools
 import enum
+import functools
 import re
 from typing import Annotated, Dict, List, TypeAlias
 
@@ -15,7 +15,6 @@ from pydantic import (
 )
 
 from conda_store_server._internal.schema import ALLOWED_CHARACTERS
-
 
 # An ARN is a string which matches namespaces and environments. For example:
 #     */*          matches all environments

--- a/conda-store-server/conda_store_server/server/schema.py
+++ b/conda-store-server/conda_store_server/server/schema.py
@@ -1,0 +1,66 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+import datetime
+import functools
+import enum
+import re
+from typing import Annotated, Dict, List, TypeAlias
+
+from pydantic import (
+    BaseModel,
+    Field,
+    StringConstraints,
+)
+
+from conda_store_server._internal.schema import ALLOWED_CHARACTERS
+
+
+# An ARN is a string which matches namespaces and environments. For example:
+#     */*          matches all environments
+#     */team       matches all environments named 'team' in any namespace
+#
+# Namespaces and environment names cannot contain "*" ":" "#" " " "/"
+ARN_ALLOWED = f"^([{ALLOWED_CHARACTERS}*]+)/([{ALLOWED_CHARACTERS}*]+)$"
+ARN_ALLOWED_REGEX = re.compile(ARN_ALLOWED)
+
+
+def _datetime_factory(offset: datetime.timedelta):
+    """Utcnow datetime + timezone as string"""
+    return datetime.datetime.utcnow() + offset
+
+
+RoleBindings: TypeAlias = Dict[
+    Annotated[str, StringConstraints(pattern=ARN_ALLOWED)], List[str]
+]
+
+
+class Permissions(enum.Enum):
+    """Permissions map to conda-store actions"""
+
+    ENVIRONMENT_CREATE = "environment:create"
+    ENVIRONMENT_READ = "environment::read"
+    ENVIRONMENT_UPDATE = "environment::update"
+    ENVIRONMENT_DELETE = "environment::delete"
+    ENVIRONMENT_SOLVE = "environment::solve"
+    BUILD_CANCEL = "build::cancel"
+    BUILD_DELETE = "build::delete"
+    NAMESPACE_CREATE = "namespace::create"
+    NAMESPACE_READ = "namespace::read"
+    NAMESPACE_UPDATE = "namespace::update"
+    NAMESPACE_DELETE = "namespace::delete"
+    NAMESPACE_ROLE_MAPPING_CREATE = "namespace-role-mapping::create"
+    NAMESPACE_ROLE_MAPPING_READ = "namespace-role-mapping::read"
+    NAMESPACE_ROLE_MAPPING_UPDATE = "namespace-role-mapping::update"
+    NAMESPACE_ROLE_MAPPING_DELETE = "namespace-role-mapping::delete"
+    SETTING_READ = "setting::read"
+    SETTING_UPDATE = "setting::update"
+
+
+class AuthenticationToken(BaseModel):
+    exp: datetime.datetime = Field(
+        default_factory=functools.partial(_datetime_factory, datetime.timedelta(days=1))
+    )
+    primary_namespace: str = "default"
+    role_bindings: RoleBindings = {}

--- a/conda-store-server/tests/_internal/server/views/test_api.py
+++ b/conda-store-server/tests/_internal/server/views/test_api.py
@@ -15,13 +15,14 @@ from fastapi.testclient import TestClient
 
 from conda_store_server import CONDA_STORE_DIR, __version__
 from conda_store_server._internal import schema
+from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal.server import dependencies
 
 
 @contextlib.contextmanager
 def mock_entity_role_bindings(
     testclient: TestClient,
-    role_bindings: schema.RoleBindings,
+    role_bindings: auth_schema.RoleBindings,
 ):
     """Override the entity role bindings for the FastAPI app temporarily.
 
@@ -29,12 +30,12 @@ def mock_entity_role_bindings(
     ----------
     testclient : TestClient
         FastAPI application for which the entity should be mocked
-    role_bindings : schema.RoleBindings
+    role_bindings : auth_schema.RoleBindings
         Role bindings that the mocked entity should have
     """
 
     def mock_get_entity():
-        return schema.AuthenticationToken(role_bindings=role_bindings)
+        return auth_schema.AuthenticationToken(role_bindings=role_bindings)
 
     testclient.app.dependency_overrides[dependencies.get_entity] = mock_get_entity
 
@@ -63,9 +64,9 @@ def test_api_permissions_unauth(testclient):
     assert r.data.entity_permissions == {
         "default/*": sorted(
             [
-                schema.Permissions.ENVIRONMENT_READ.value,
-                schema.Permissions.NAMESPACE_READ.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
+                auth_schema.Permissions.ENVIRONMENT_READ.value,
+                auth_schema.Permissions.NAMESPACE_READ.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
             ]
         )
     }
@@ -82,37 +83,37 @@ def test_api_permissions_auth(testclient, authenticate):
     assert r.data.entity_permissions == {
         "*/*": sorted(
             [
-                schema.Permissions.ENVIRONMENT_CREATE.value,
-                schema.Permissions.ENVIRONMENT_READ.value,
-                schema.Permissions.ENVIRONMENT_UPDATE.value,
-                schema.Permissions.ENVIRONMENT_DELETE.value,
-                schema.Permissions.ENVIRONMENT_SOLVE.value,
-                schema.Permissions.BUILD_CANCEL.value,
-                schema.Permissions.BUILD_DELETE.value,
-                schema.Permissions.NAMESPACE_CREATE.value,
-                schema.Permissions.NAMESPACE_READ.value,
-                schema.Permissions.NAMESPACE_DELETE.value,
-                schema.Permissions.NAMESPACE_UPDATE.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_CREATE.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_UPDATE.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_DELETE.value,
-                schema.Permissions.SETTING_READ.value,
-                schema.Permissions.SETTING_UPDATE.value,
+                auth_schema.Permissions.ENVIRONMENT_CREATE.value,
+                auth_schema.Permissions.ENVIRONMENT_READ.value,
+                auth_schema.Permissions.ENVIRONMENT_UPDATE.value,
+                auth_schema.Permissions.ENVIRONMENT_DELETE.value,
+                auth_schema.Permissions.ENVIRONMENT_SOLVE.value,
+                auth_schema.Permissions.BUILD_CANCEL.value,
+                auth_schema.Permissions.BUILD_DELETE.value,
+                auth_schema.Permissions.NAMESPACE_CREATE.value,
+                auth_schema.Permissions.NAMESPACE_READ.value,
+                auth_schema.Permissions.NAMESPACE_DELETE.value,
+                auth_schema.Permissions.NAMESPACE_UPDATE.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_CREATE.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_UPDATE.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_DELETE.value,
+                auth_schema.Permissions.SETTING_READ.value,
+                auth_schema.Permissions.SETTING_UPDATE.value,
             ]
         ),
         "default/*": sorted(
             [
-                schema.Permissions.ENVIRONMENT_READ.value,
-                schema.Permissions.NAMESPACE_READ.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
+                auth_schema.Permissions.ENVIRONMENT_READ.value,
+                auth_schema.Permissions.NAMESPACE_READ.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
             ]
         ),
         "filesystem/*": sorted(
             [
-                schema.Permissions.ENVIRONMENT_READ.value,
-                schema.Permissions.NAMESPACE_READ.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
+                auth_schema.Permissions.ENVIRONMENT_READ.value,
+                auth_schema.Permissions.NAMESPACE_READ.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
             ]
         ),
     }
@@ -285,7 +286,7 @@ def test_api_list_environments_jwt(
     envs_accessible_to_target.extend(["name1", "name2"])
 
     jwt = conda_store_server.authentication.authentication.encrypt_token(
-        schema.AuthenticationToken(role_bindings=target_role_bindings)
+        auth_schema.AuthenticationToken(role_bindings=target_role_bindings)
     )
 
     # Override the get_entity dependency to allow the request to appear to be

--- a/conda-store-server/tests/_internal/server/views/test_api.py
+++ b/conda-store-server/tests/_internal/server/views/test_api.py
@@ -15,8 +15,8 @@ from fastapi.testclient import TestClient
 
 from conda_store_server import CONDA_STORE_DIR, __version__
 from conda_store_server._internal import schema
-from conda_store_server.server import schema as auth_schema
 from conda_store_server._internal.server import dependencies
+from conda_store_server.server import schema as auth_schema
 
 
 @contextlib.contextmanager

--- a/conda-store-server/tests/server/test_auth.py
+++ b/conda-store-server/tests/server/test_auth.py
@@ -7,7 +7,7 @@ import uuid
 
 import pytest
 
-from conda_store_server._internal.schema import AuthenticationToken, Permissions
+from conda_store_server.server.schema import AuthenticationToken, Permissions
 from conda_store_server.server.auth import (
     AuthenticationBackend,
     RBACAuthorizationBackend,

--- a/conda-store-server/tests/server/test_auth.py
+++ b/conda-store-server/tests/server/test_auth.py
@@ -7,11 +7,11 @@ import uuid
 
 import pytest
 
-from conda_store_server.server.schema import AuthenticationToken, Permissions
 from conda_store_server.server.auth import (
     AuthenticationBackend,
     RBACAuthorizationBackend,
 )
+from conda_store_server.server.schema import AuthenticationToken, Permissions
 
 
 @pytest.mark.parametrize(

--- a/docusaurus-docs/conda-store/references/auth.md
+++ b/docusaurus-docs/conda-store/references/auth.md
@@ -34,7 +34,7 @@ user. Similar to JupyterHub
 method. This method is the primary way to customize authentication. It
 is responsible for checking that the user credentials to login are
 correct as well as returning a dictionary following the schema
-`conda_store_server._internal.schema.AuthenticationToken`. This stores a
+`conda_store_server.auth.schema.AuthenticationToken`. This stores a
 `primary_namespace` for a given authenticated service or user. In
 addition a dictionary of `<namespace>/<name>` map to a set of
 roles. See the Authorization model to better understand the key to set

--- a/docusaurus-docs/conda-store/references/auth.md
+++ b/docusaurus-docs/conda-store/references/auth.md
@@ -34,7 +34,7 @@ user. Similar to JupyterHub
 method. This method is the primary way to customize authentication. It
 is responsible for checking that the user credentials to login are
 correct as well as returning a dictionary following the schema
-`conda_store_server.auth.schema.AuthenticationToken`. This stores a
+`conda_store_server.server.schema.AuthenticationToken`. This stores a
 `primary_namespace` for a given authenticated service or user. In
 addition a dictionary of `<namespace>/<name>` map to a set of
 roles. See the Authorization model to better understand the key to set

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,6 +30,7 @@ import requests
 import conda_store_server
 
 from conda_store_server._internal import schema
+from conda_store_server.server import schema as auth_schema
 
 from .conftest import CONDA_STORE_BASE_URL
 
@@ -91,9 +92,9 @@ def test_api_permissions_unauth(testclient):
     assert r.data.entity_permissions == {
         "default/*": sorted(
             [
-                schema.Permissions.ENVIRONMENT_READ.value,
-                schema.Permissions.NAMESPACE_READ.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
+                auth_schema.Permissions.ENVIRONMENT_READ.value,
+                auth_schema.Permissions.NAMESPACE_READ.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
             ]
         )
     }
@@ -111,37 +112,37 @@ def test_api_permissions_auth(testclient):
     assert r.data.entity_permissions == {
         "*/*": sorted(
             [
-                schema.Permissions.ENVIRONMENT_CREATE.value,
-                schema.Permissions.ENVIRONMENT_READ.value,
-                schema.Permissions.ENVIRONMENT_UPDATE.value,
-                schema.Permissions.ENVIRONMENT_DELETE.value,
-                schema.Permissions.ENVIRONMENT_SOLVE.value,
-                schema.Permissions.BUILD_CANCEL.value,
-                schema.Permissions.BUILD_DELETE.value,
-                schema.Permissions.NAMESPACE_CREATE.value,
-                schema.Permissions.NAMESPACE_READ.value,
-                schema.Permissions.NAMESPACE_DELETE.value,
-                schema.Permissions.NAMESPACE_UPDATE.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_CREATE.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_UPDATE.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_DELETE.value,
-                schema.Permissions.SETTING_READ.value,
-                schema.Permissions.SETTING_UPDATE.value,
+                auth_schema.Permissions.ENVIRONMENT_CREATE.value,
+                auth_schema.Permissions.ENVIRONMENT_READ.value,
+                auth_schema.Permissions.ENVIRONMENT_UPDATE.value,
+                auth_schema.Permissions.ENVIRONMENT_DELETE.value,
+                auth_schema.Permissions.ENVIRONMENT_SOLVE.value,
+                auth_schema.Permissions.BUILD_CANCEL.value,
+                auth_schema.Permissions.BUILD_DELETE.value,
+                auth_schema.Permissions.NAMESPACE_CREATE.value,
+                auth_schema.Permissions.NAMESPACE_READ.value,
+                auth_schema.Permissions.NAMESPACE_DELETE.value,
+                auth_schema.Permissions.NAMESPACE_UPDATE.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_CREATE.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_UPDATE.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_DELETE.value,
+                auth_schema.Permissions.SETTING_READ.value,
+                auth_schema.Permissions.SETTING_UPDATE.value,
             ]
         ),
         "default/*": sorted(
             [
-                schema.Permissions.ENVIRONMENT_READ.value,
-                schema.Permissions.NAMESPACE_READ.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
+                auth_schema.Permissions.ENVIRONMENT_READ.value,
+                auth_schema.Permissions.NAMESPACE_READ.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
             ]
         ),
         "filesystem/*": sorted(
             [
-                schema.Permissions.ENVIRONMENT_READ.value,
-                schema.Permissions.NAMESPACE_READ.value,
-                schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
+                auth_schema.Permissions.ENVIRONMENT_READ.value,
+                auth_schema.Permissions.NAMESPACE_READ.value,
+                auth_schema.Permissions.NAMESPACE_ROLE_MAPPING_READ.value,
             ]
         ),
     }


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/1042

## Description

This will allow users to define their own auth modules without dependings on internal schemas. 

In particular this enables nebari to not depend on the `conda_store_server._internal.schema` module for setting up the keycloak auth backend (ref. https://github.com/nebari-dev/nebari/blob/f39467679ce2dac84385f1d6d4ec698befd7c126/src/_nebari/stages/kubernetes_services/template/modules/kubernetes/services/conda-store/config/conda_store_config.py#L14).

This is intended as a stop gap solution until [conda-store support authentication plugins](https://github.com/conda-incubator/conda-store/issues/1031). As such, this PR aims to not make any changes that will make it more difficult to move towards auth plugins.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
