### PR TITLE
Add build archived on column

### DIFF
--- a/conda-store-server/conda_store_server/_internal/alembic/versions/8c5abec6e601_add_build_archived_on_column.py
+++ b/conda-store-server/conda_store_server/_internal/alembic/versions/8c5abec6e601_add_build_archived_on_column.py
@@ -1,0 +1,30 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+"""add build.archived_on column
+
+Revision ID: 8c5abec6e601
+Revises: 89637f546129
+Create Date: 2025-01-15 13:33:19.529794
+
+"""
+from alembic import op
+from sqlalchemy import Column, DateTime
+
+# revision identifiers, used by Alembic.
+revision = '8c5abec6e601'
+down_revision = '89637f546129'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'build',
+        Column("archived_on", DateTime, default=None),
+    )
+
+
+def downgrade():
+    op.drop_column('build', 'archived_on')

--- a/conda-store-server/conda_store_server/_internal/orm.py
+++ b/conda-store-server/conda_store_server/_internal/orm.py
@@ -266,6 +266,7 @@ class Build(Base):
     started_on: Mapped[datetime.datetime] = mapped_column(DateTime, default=None)
     ended_on: Mapped[datetime.datetime] = mapped_column(DateTime, default=None)
     deleted_on: Mapped[datetime.datetime] = mapped_column(DateTime, default=None)
+    archived_on: Mapped[datetime.datetime] = mapped_column(DateTime, default=None)
 
     # Only used by build_key_version 3, not necessary for earlier versions
     hash: Mapped[str] = mapped_column(Unicode(32), default=None)

--- a/conda-store-server/tests/_internal/alembic/version/test_8c5abec6e601_add_build_archived_on_column.py
+++ b/conda-store-server/tests/_internal/alembic/version/test_8c5abec6e601_add_build_archived_on_column.py
@@ -1,0 +1,65 @@
+# Copyright (c) conda-store development team. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+import pytest
+import datetime
+
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+
+from conda_store_server import api
+from conda_store_server._internal import orm
+
+
+def test_add_build_archived_on_column_basic(
+    conda_store, alembic_config, alembic_runner
+):
+    """Simply run the upgrade and downgrade for this migration"""
+    # migrate all the way to the target revision
+    alembic_runner.migrate_up_to("8c5abec6e601")
+
+    # ensure the archived_on column exists
+    with conda_store.session_factory() as db:
+        db.execute(text("SELECT archived_on from build"))
+
+    # try downgrading
+    alembic_runner.migrate_down_one()
+
+    # ensure the archived_on column does not exists
+    with conda_store.session_factory() as db:
+        with pytest.raises(OperationalError):
+            db.execute(text("SELECT archived_on from build"))
+
+    # try upgrading once more
+    alembic_runner.migrate_up_one()
+
+    # ensure the archived_on column exists
+    with conda_store.session_factory() as db:
+        db.execute(text("SELECT archived_on from build"))
+
+
+def test_downgrade_works_for_populated_column(
+    conda_store, alembic_config, alembic_runner, seed_conda_store
+):
+    """Try to run the downgrade part of the migration when the `archived_on` column has data"""
+    # migrate all the way to the target revision
+    alembic_runner.migrate_up_to("8c5abec6e601")
+
+    # ensure the archived_on column exists
+    with conda_store.session_factory() as db:
+        db.execute(text("SELECT archived_on from build"))
+
+    # update demo data to have data in archived_on column
+    with conda_store.session_factory() as db:
+        build = api.get_build(db, 1)
+        build.archived_on = datetime.datetime.now(datetime.UTC)
+        db.commit()
+
+    # try downgrading
+    alembic_runner.migrate_down_one()
+
+    # ensure the archived_on column does not exists
+    with conda_store.session_factory() as db:
+        with pytest.raises(OperationalError):
+            db.execute(text("SELECT archived_on from build"))


### PR DESCRIPTION
## Description

related issue: https://github.com/conda-incubator/conda-store/issues/947

This PR adds a migration for adding a new `archived_on` column to the build table. Along with https://github.com/conda-incubator/conda-store/pull/1047, it will enable marking builds as archived.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?


