### PR TITLE
Fix user-journey tests for running against non-default targets

### DIFF
--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -96,6 +96,7 @@ def test_user_login_and_create_shared_environment(
 
     dev_api = utils.API(
         base_url=base_url,
+        verify_ssl=verify_ssl,
         token=api.create_token(
             namespace,
             "developer",

--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -29,7 +29,8 @@ def verify_ssl() -> bool:
     If CONDA_STORE_TEST_VERIFY_SSL is 0, ssl verification is disabled. For all
     other inputs, ssl verification is enabled.
     """
-    return bool(os.environ.get("CONDA_STORE_TEST_VERIFY_SSL", True))
+    verify = os.environ.get("CONDA_STORE_TEST_VERIFY_SSL", "true")
+    return not verify.lower() in ("0", "false")
 
 
 @pytest.mark.user_journey

--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -60,10 +60,10 @@ def test_admin_user_can_create_environment(
     ],
 )
 def test_admin_login_and_delete_shared_environment(
-    base_url: str, specification_path: str, verify_ssl: bool
+    base_url: str, token: str,specification_path: str, verify_ssl: bool
 ) -> None:
     """Test that an admin can login and create/delete an env in a shared namespace."""
-    api = utils.API(base_url=base_url, verify_ssl=verify_ssl)
+    api = utils.API(base_url=base_url, token=token, verify_ssl=verify_ssl)
 
     # Create a shared namespace; default permissions for namepace/environment
     # */* is admin
@@ -85,10 +85,10 @@ def test_admin_login_and_delete_shared_environment(
     ],
 )
 def test_user_login_and_create_shared_environment(
-    base_url: str, specification_path: str, verify_ssl: bool
+    base_url: str, token: str, specification_path: str, verify_ssl: bool
 ) -> None:
     """Test that a user can login and create an environment in a shared namespace."""
-    api = utils.API(base_url=base_url, verify_ssl=verify_ssl)
+    api = utils.API(base_url=base_url, token=token, verify_ssl=verify_ssl)
 
     # Create a shared namespace; default permissions for namepace/environment
     # */* is admin
@@ -112,13 +112,13 @@ def test_user_login_and_create_shared_environment(
 
 
 @pytest.mark.user_journey
-def test_admin_set_active_build(base_url: str, verify_ssl: bool):
+def test_admin_set_active_build(base_url: str, token: str, verify_ssl: bool):
     """Test that an admin can delete environments."""
     specs = [
         "tests/user_journeys/test_data/simple_environment.yaml",
         "tests/user_journeys/test_data/simple_environment2.yaml",
     ]
-    api = utils.API(base_url=base_url, verify_ssl=verify_ssl)
+    api = utils.API(base_url=base_url, token=token, verify_ssl=verify_ssl)
     namespace = api.create_namespace().json()["data"]["name"]
     envs = set()
     for spec in specs:
@@ -160,9 +160,9 @@ def test_admin_set_active_build(base_url: str, verify_ssl: bool):
 
 
 @pytest.mark.user_journey
-def test_failed_build_logs(base_url: str, verify_ssl: bool):
+def test_failed_build_logs(base_url: str, token: str, verify_ssl: bool):
     """Test that a user can access logs for a failed build."""
-    api = utils.API(base_url=base_url, verify_ssl=verify_ssl)
+    api = utils.API(base_url=base_url, token=token, verify_ssl=verify_ssl)
     namespace = "default"
     build_request = api.create_environment(
         namespace,
@@ -182,9 +182,9 @@ def test_failed_build_logs(base_url: str, verify_ssl: bool):
 
 
 @pytest.mark.user_journey
-def test_cancel_build(base_url: str, verify_ssl: bool):
+def test_cancel_build(base_url: str, token: str, verify_ssl: bool):
     """Test that a user cancel a build in progress."""
-    api = utils.API(base_url=base_url, verify_ssl=verify_ssl)
+    api = utils.API(base_url=base_url, token=token, verify_ssl=verify_ssl)
     namespace = "default"
     build_id = api.create_environment(
         namespace,
@@ -214,9 +214,9 @@ def test_cancel_build(base_url: str, verify_ssl: bool):
 
 
 @pytest.mark.user_journey
-def test_get_lockfile(base_url: str, verify_ssl: bool):
+def test_get_lockfile(base_url: str, token: str, verify_ssl: bool):
     """Test that an admin can access a valid lockfile for a build."""
-    api = utils.API(base_url=base_url, verify_ssl=verify_ssl)
+    api = utils.API(base_url=base_url, token=token, verify_ssl=verify_ssl)
     namespace = "default"
     build_request = api.create_environment(
         namespace,

--- a/conda-store-server/tests/user_journeys/test_user_journeys.py
+++ b/conda-store-server/tests/user_journeys/test_user_journeys.py
@@ -30,7 +30,7 @@ def verify_ssl() -> bool:
     other inputs, ssl verification is enabled.
     """
     verify = os.environ.get("CONDA_STORE_TEST_VERIFY_SSL", "true")
-    return not verify.lower() in ("0", "false")
+    return verify.lower() not in ("0", "false")
 
 
 @pytest.mark.user_journey
@@ -60,7 +60,7 @@ def test_admin_user_can_create_environment(
     ],
 )
 def test_admin_login_and_delete_shared_environment(
-    base_url: str, token: str,specification_path: str, verify_ssl: bool
+    base_url: str, token: str, specification_path: str, verify_ssl: bool
 ) -> None:
     """Test that an admin can login and create/delete an env in a shared namespace."""
     api = utils.API(base_url=base_url, token=token, verify_ssl=verify_ssl)

--- a/conda-store-server/tests/user_journeys/utils/api_utils.py
+++ b/conda-store-server/tests/user_journeys/utils/api_utils.py
@@ -136,7 +136,7 @@ class API:
         """Create a token with a specified role in a specified namespace."""
         json_data = {
             "primary_namespace": default_namespace,
-            "expiration": time_utils.get_iso8601_time(1),
+            #"expiration": time_utils.get_iso8601_time(1),
             "role_bindings": {f"{namespace}/*": [role]},
         }
         return self._make_request("api/v1/token", method="POST", json_data=json_data)

--- a/conda-store-server/tests/user_journeys/utils/api_utils.py
+++ b/conda-store-server/tests/user_journeys/utils/api_utils.py
@@ -136,7 +136,6 @@ class API:
         """Create a token with a specified role in a specified namespace."""
         json_data = {
             "primary_namespace": default_namespace,
-            #"expiration": time_utils.get_iso8601_time(1),
             "role_bindings": {f"{namespace}/*": [role]},
         }
         return self._make_request("api/v1/token", method="POST", json_data=json_data)

--- a/conda-store-server/tests/user_journeys/utils/api_utils.py
+++ b/conda-store-server/tests/user_journeys/utils/api_utils.py
@@ -12,8 +12,6 @@ from typing import Any, Callable, Dict, Optional, Union
 
 import requests
 
-import utils.time_utils as time_utils
-
 TIMEOUT = 10
 
 


### PR DESCRIPTION
## Description

This PR makes a variety of fixes to the user journey tests in order to run them against non default targets (eg. like nebari's conda store deployment). This is required for https://github.com/nebari-dev/nebari/pull/2895

### Fix `CONDA_STORE_TEST_VERIFY_SSL`
Previously setting any value for `CONDA_STORE_TEST_VERIFY_SSL`  resulted in enabling ssl verification. So, setting `CONDA_STORE_TEST_VERIFY_SSL=0` or `CONDA_STORE_TEST_VERIFY_SSL=false` enabled ssl verification. This is because strings are truthy. 

This PR fixes this by checking if the passed in env var is one of `0`, `false` or `False` in order to determine if tests should verify SSL.

### Use `CONDA_STORE_TOKEN` 
Previously all but one conda-store user journey tests used the `CONDA_STORE_TOKEN` as auth when running tests. This PR extends this so that all user journey tests can use the provided auth token for auth.

### Ensure new api contexts are valid
Previously, some tests created new utils.API instances. However, the generated tokens had invalid expiry values and did not respect the SSL settings. 


## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

