### PR TITLE
Mount code into docker container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./tests/assets/environments:/opt/environments:ro
       - ./tests/assets/conda_store_config.py:/opt/conda_store/conda_store_config.py:ro
+      - ./conda-store-server:/opt/conda-store-server:ro
     depends_on:
       conda-store-server:
         condition: service_healthy
@@ -36,6 +37,7 @@ services:
         condition: service_healthy
     volumes:
       - ./tests/assets/conda_store_config.py:/opt/conda_store/conda_store_config.py:ro
+      - ./conda-store-server:/opt/conda-store-server:ro
     healthcheck:
       test:
         ["CMD", "curl", "--fail", "http://localhost:8080/conda-store/api/v1/"]


### PR DESCRIPTION
## Description

This PR mounts the conda-store code into the running docker containers. So, if you are iterating on server side code, your changes will automatically get picked up (and the server will reload with hot reloading).

This require devs to have conda-store-ui vendored. This can be done
```
$ cd conda-store-server
$ hatch build
```

Users can also run against a particular version of the ui
```
$  LOCAL_UI=/home/sophia/projects/conda-store-ui hatch build
```

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

