### PR TITLE
Trim conda-store package dependencies

### DIFF
--- a/conda-store/pyproject.toml
+++ b/conda-store/pyproject.toml
@@ -46,10 +46,6 @@ dependencies = [
   "yarl",
   "aiohttp>=3.8.1",
   "ruamel.yaml",
-  "jupyterhub<2.0.0",
-  "jupyterlab>=4.0.0",
-  "jupyter-launcher-shortcuts",
-  "jupyterlab-conda-store",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/1053

## Description

The conda-store (cli) package does not have dependencies on jupyter - cleaning up these dependencies. 

For reference, you can also check against the conda package recipe https://github.com/conda-incubator/conda-store/blob/main/recipe/meta.yaml#L34-L43 (which does not express any dependencies on jupyter).

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

