### PR TITLE
Build and release a arm64 docker image as part of the release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,6 +119,9 @@ jobs:
         docker-image:
           - conda-store
           - conda-store-server
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: "Checkout Repository 🛎"
         uses: actions/checkout@v4
@@ -188,4 +191,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/1043

## Description

Currently we build and release docker images for amd64 and arm64 platforms on each merge to main, but do not release arm64 images on releases.

This PR will update the release process to also ship arm64 docker images.


