### PR TITLE
Allow Namespace pydantic model to have a null metadata_ entry

### DIFF
--- a/conda-store-server/conda_store_server/_internal/schema.py
+++ b/conda-store-server/conda_store_server/_internal/schema.py
@@ -81,7 +81,7 @@ class NamespaceRoleMappingV2(BaseModel):
 class Namespace(BaseModel):
     id: int
     name: Annotated[str, StringConstraints(pattern=f"^[{ALLOWED_CHARACTERS}]+$")]  # noqa: F722
-    metadata_: Dict[str, Any] = None
+    metadata_: Optional[Dict[str, Any]] = None
     role_mappings: List[NamespaceRoleMapping] = []
     model_config = ConfigDict(from_attributes=True)
 

--- a/conda-store-server/tests/_internal/server/views/test_api.py
+++ b/conda-store-server/tests/_internal/server/views/test_api.py
@@ -175,7 +175,9 @@ def test_api_list_namespace_auth(testclient, seed_conda_store, authenticate):
     assert sorted([_.name for _ in r.data]) == ["default", "namespace1", "namespace2"]
 
 
-def test_api_list_namespace_including_missing_metadata_(testclient, seed_namespace_with_edge_cases, authenticate):
+def test_api_list_namespace_including_missing_metadata_(
+    testclient, seed_namespace_with_edge_cases, authenticate
+):
     response = testclient.get("api/v1/namespace")
     response.raise_for_status()
 

--- a/conda-store-server/tests/_internal/server/views/test_api.py
+++ b/conda-store-server/tests/_internal/server/views/test_api.py
@@ -178,8 +178,8 @@ def test_api_list_namespace_auth(testclient, seed_conda_store, authenticate):
 def test_api_list_namespace_including_missing_metadata_(
     testclient, seed_namespace_with_edge_cases, authenticate
 ):
-    """Test that a namespace with metadata_ = None can be retrieved. 
-    
+    """Test that a namespace with metadata_ = None can be retrieved.
+
     See https://github.com/conda-incubator/conda-store/issues/1062
     for additional context.
     """

--- a/conda-store-server/tests/_internal/server/views/test_api.py
+++ b/conda-store-server/tests/_internal/server/views/test_api.py
@@ -178,6 +178,11 @@ def test_api_list_namespace_auth(testclient, seed_conda_store, authenticate):
 def test_api_list_namespace_including_missing_metadata_(
     testclient, seed_namespace_with_edge_cases, authenticate
 ):
+    """Test that a namespace with metadata_ = None can be retrieved. 
+    
+    See https://github.com/conda-incubator/conda-store/issues/1062
+    for additional context.
+    """
     response = testclient.get("api/v1/namespace")
     response.raise_for_status()
 

--- a/conda-store-server/tests/_internal/server/views/test_api.py
+++ b/conda-store-server/tests/_internal/server/views/test_api.py
@@ -175,6 +175,16 @@ def test_api_list_namespace_auth(testclient, seed_conda_store, authenticate):
     assert sorted([_.name for _ in r.data]) == ["default", "namespace1", "namespace2"]
 
 
+def test_api_list_namespace_including_missing_metadata_(testclient, seed_namespace_with_edge_cases, authenticate):
+    response = testclient.get("api/v1/namespace")
+    response.raise_for_status()
+
+    r = schema.APIListNamespace.model_validate(response.json())
+    assert r.status == schema.APIStatus.OK
+    namespaces = [_.name for _ in r.data]
+    assert "namespace_missing_meta" in namespaces
+
+
 def test_api_get_namespace_unauth(testclient, seed_conda_store):
     response = testclient.get("api/v1/namespace/default")
     response.raise_for_status()

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -421,7 +421,7 @@ def alembic_config(conda_store):
 def seed_namespace_with_edge_cases(db: Session, conda_store):
     namespaces = [
         orm.Namespace(name="normal_namespace"),
-        orm.Namespace(name="namespace_missing_meta", metadata_=None)
+        orm.Namespace(name="namespace_missing_meta", metadata_=None),
     ]
 
     for namespace in namespaces:

--- a/conda-store-server/tests/conftest.py
+++ b/conda-store-server/tests/conftest.py
@@ -417,6 +417,18 @@ def alembic_config(conda_store):
     return {"file": ini_file}
 
 
+@pytest.fixture
+def seed_namespace_with_edge_cases(db: Session, conda_store):
+    namespaces = [
+        orm.Namespace(name="normal_namespace"),
+        orm.Namespace(name="namespace_missing_meta", metadata_=None)
+    ]
+
+    for namespace in namespaces:
+        db.add(namespace)
+    db.commit()
+
+
 def _seed_conda_store(
     db: Session,
     conda_store,


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/1062

## Description

This PR updates the pydantic model for `Namespace` so that the `metadata_` field can be null. This field is nullable, and the default value is an empty dict:

```
class Namespace(Base):
    """Namespace for resources"""

    . . .

    metadata_: Mapped[Optional[dict]] = mapped_column(JSON, default=dict, nullable=True)

    . . .
```

In order for pydantic models to allow values to be `None`, they must set them as `Optional`. If not, an error will be thrown. 

In older deployments on conda-store it is possible for this field to actually be `NULL` (see the explanation https://github.com/conda-incubator/conda-store/issues/1062#issuecomment-2622435285), resulting in an error.

### Additional notes

While sorting this out I also checked for other orm fields that were explicitly set to `nullable=True` and ensured that their pydantic counterparts are set to `Optional`.


## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

