### PR TITLE
[ENH] Add a log formatter to redact sensitive information from output

### DIFF
--- a/conda-store-server/conda_store_server/_internal/log.py
+++ b/conda-store-server/conda_store_server/_internal/log.py
@@ -1,0 +1,18 @@
+import logging
+
+
+class RedactingFormatter(logging.Formatter):
+    """A logging formatter which redacts items on the blocklist."""
+
+    def __init__(self, *args, blocklist):
+        if blocklist is None:
+            blocklist = []
+
+        self.blocklist = blocklist
+        super().__init__(*args)
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = super().format(record)
+        for item in self.blocklist:
+            message = message.replace(item, "*" * len(item))
+        return message


### PR DESCRIPTION
Fixes #1035.

## Description

This pull request:

- Adds a logging formatter to redact a blocklist of sensitive terms from log output. So far only the `database_url` is redacted, but more can easily be added to the list.

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?