### PR TITLE
Re-add docker blob build artifact type

### DIFF
--- a/conda-store-server/conda_store_server/_internal/schema.py
+++ b/conda-store-server/conda_store_server/_internal/schema.py
@@ -104,7 +104,13 @@ class BuildArtifactType(str, enum.Enum):
     CONDA_PACK = "CONDA_PACK"
     DOCKER_MANIFEST = "DOCKER_MANIFEST"
     CONSTRUCTOR_INSTALLER = "CONSTRUCTOR_INSTALLER"
-    _ = "CONTAINER_REGISTRY"
+
+    # Deprecated
+    # Old database may still have docker or container build artifacts.
+    # So, these enum values must stay in order to remain backwards compatible
+    # however, no new artifacts of these types should be created.
+    CONTAINER_REGISTRY = "CONTAINER_REGISTRY"
+    DOCKER_BLOB = "DOCKER_BLOB"
 
 
 class BuildStatus(enum.Enum):

--- a/conda-store-server/tests/_internal/test_schema.py
+++ b/conda-store-server/tests/_internal/test_schema.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+import datetime
 import pytest
 
 from conda_store_server._internal import schema
@@ -62,3 +63,31 @@ def test_parse_lockfile_obj(test_lockfile):
     }
     specification = schema.LockfileSpecification.model_validate(lockfile_spec)
     assert specification.model_dump()["lockfile"] == test_lockfile
+
+@pytest.mark.parametrize(
+    ("build"),
+    [
+        {
+            "id": 1,
+            "environment_id": 1,
+            "status": "BUILDING",
+            "scheduled_on": datetime.datetime.now(),
+            "size": 123,
+        },
+        {
+            "id": 2,
+            "environment_id": 1,
+            "status": "BUILDING",
+            "scheduled_on": datetime.datetime.now(),
+            "size": 123,
+            "build_artifacts": [
+                {"id": 1, "artifact_type": "YAML", "key": "not_a_real_key"},
+                {"id": 2, "artifact_type": "DOCKER_BLOB", "key": "not_a_real_key"},
+                {"id": 3, "artifact_type": "CONTAINER_REGISTRY", "key": "not_a_real_key"},
+            ]
+        }
+    ],
+)
+def test_parse_build(build):
+    output = schema.Build.model_validate(build).model_dump()
+    assert output is not None

--- a/conda-store-server/tests/_internal/test_schema.py
+++ b/conda-store-server/tests/_internal/test_schema.py
@@ -3,6 +3,7 @@
 # license that can be found in the LICENSE file.
 
 import datetime
+
 import pytest
 
 from conda_store_server._internal import schema
@@ -64,6 +65,7 @@ def test_parse_lockfile_obj(test_lockfile):
     specification = schema.LockfileSpecification.model_validate(lockfile_spec)
     assert specification.model_dump()["lockfile"] == test_lockfile
 
+
 @pytest.mark.parametrize(
     ("build"),
     [
@@ -83,9 +85,13 @@ def test_parse_lockfile_obj(test_lockfile):
             "build_artifacts": [
                 {"id": 1, "artifact_type": "YAML", "key": "not_a_real_key"},
                 {"id": 2, "artifact_type": "DOCKER_BLOB", "key": "not_a_real_key"},
-                {"id": 3, "artifact_type": "CONTAINER_REGISTRY", "key": "not_a_real_key"},
-            ]
-        }
+                {
+                    "id": 3,
+                    "artifact_type": "CONTAINER_REGISTRY",
+                    "key": "not_a_real_key",
+                },
+            ],
+        },
     ],
 )
 def test_parse_build(build):


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/conda-store/issues/1085


## Description

This PR re-adds the `DOCKER_BLOB` build artifact enum value. This is required for backwards compatibility with old database entries.

### To test manually:
* insert a new build into the database with the `docker_blob` artifact type
one way to do this is to add a new artifact to an existing build. For example (with the docker compose setup):
```
$ docker compose exec -it psql
# \c conda-store

// see what build artifacts exist
conda-store=# select * from build_artifact;
 id | build_id | artifact_type |                                  key                                   
----+----------+---------------+------------------------------------------------------------------------
  1 |        1 | LOGS          | logs/c3457167-1739296499-1-python-flask-env.log
  2 |        1 | LOCKFILE      | lockfile/c3457167-1739296499-1-python-flask-env.yml
  3 |        2 | LOGS          | logs/d448494f-1739296648-2-test.log
  4 |        1 | DIRECTORY     | /var/lib/conda-store/filesystem/c3457167-1739296499-1-python-flask-env
  5 |        1 | YAML          | yaml/c3457167-1739296499-1-python-flask-env.yml
  6 |        2 | LOCKFILE      | lockfile/d448494f-1739296648-2-test.yml
  7 |        1 | CONDA_PACK    | archive/c3457167-1739296499-1-python-flask-env.tar.gz
  8 |        2 | DIRECTORY     | /var/lib/conda-store/test/d448494f-1739296648-2-test
  9 |        2 | YAML          | yaml/d448494f-1739296648-2-test.yml
 10 |        2 | CONDA_PACK    | archive/d448494f-1739296648-2-test.tar.gz

// add a docker blob to the build with id `2`
conda-store=# insert into build_artifact (build_id, artifact_type, key)  values (2, 'DOCKER_BLOB', 'idonte
xist');
INSERT 0 1
``` 


* query for the build using the api
```
$ curl http://localhost:8080/conda-store/api/v1/environment/
```

On the main branch this curl request causes an internal server error.


## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

