### PR TITLE
Add upper limit to conda-lock version

### DIFF
--- a/conda-store-server/pyproject.toml
+++ b/conda-store-server/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "python-docker",
   # we need platform dependent dependencies here
   "conda-docker; sys_platform == 'linux'",
-  "conda-lock >=1.0.5",
+  "conda-lock >=1.0.5,<3.0.0",
   "conda-pack",
   "conda-package-handling",
   "conda-package-streaming",


### PR DESCRIPTION
Fixes #1095 

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

<!-- What is the purpose of this pull request? -->

This pull request:

Adds an upper limit to `conda-lock` in the `pyproject.toml` dependencies to avoid installing `conda-lock >= 3.0.0`.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
## How to test

<!-- Steps to take to test the new feature, verify the bug is fixed, etc. Please do not just include steps for the happy path, but failure modes too. -->
