### PR TITLE
fix: ensure OAuth callback URL is a string

### DIFF
--- a/conda-store-server/conda_store_server/server/auth.py
+++ b/conda-store-server/conda_store_server/server/auth.py
@@ -747,7 +747,7 @@ class GenericOAuthAuthentication(Authentication):
     @default("oauth_callback_url")
     def _default_oauth_callback_url(self):
         def _oauth_callback_url(request: Request):
-            return request.url_for("post_login_method")
+            return str(request.url_for("post_login_method"))
 
         return _oauth_callback_url
 

--- a/conda-store-server/tests/server/test_auth.py
+++ b/conda-store-server/tests/server/test_auth.py
@@ -4,16 +4,30 @@
 
 import datetime
 import uuid
+from unittest.mock import Mock
 
 import pytest
 from fastapi import Request
+from starlette.datastructures import URL
 
 from conda_store_server.server.auth import (
     Authentication,
     AuthenticationBackend,
+    GenericOAuthAuthentication,
     RBACAuthorizationBackend,
 )
 from conda_store_server.server.schema import AuthenticationToken, Permissions
+
+
+def test_default_oauth_callback_url_is_string():
+    request = Mock(spec=Request)
+    request.url_for.return_value = URL("https://example.com/oauth_callback/")
+
+    authentication = GenericOAuthAuthentication()
+
+    assert authentication.get_oauth_callback_url(request) == (
+        "https://example.com/oauth_callback/"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #592.

## Description

This pull request:

- converts Starlette's `URL` return value to a string in the default OAuth callback
- preserves explicitly configured string and callable callback behavior
- adds a regression test covering the default callback type and value

## Pull request checklist

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?

## Additional information

The full Python pre-commit hooks (`ruff` and `ruff-format`) pass on both changed files. The aggregate pre-commit bootstrap could not initialize the unrelated Biome hook because the local npm installation rejects git dependencies with `EALLOWGIT`.

## How to test

From `conda-store-server` in the development environment:

```shell
python -m pytest tests/server/test_auth.py -q
```

This passes all 62 tests, including the new regression test, and verifies both the affected OAuth callback behavior and the surrounding authentication paths.
